### PR TITLE
Second Price Auctions

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -121,7 +121,7 @@
         1. The team that wins the FAAB auction that takes place on Yahoo wins the player and is forced to drop any other players if specificed on Yahoo, but must only pay the price of the second highest bid on the same player.
             1. If there is no second bidder, the second highest bid will be considered 0.
         1. The Yahoo interface will take the full FAAB from the highest bidder and the difference between this bid and the second highest bid will not be returned until the final game is played for the week, but no later than Tuesday at 1pm (EST).
-        1. Managers may not make any claim to FAAB returned as a difference between the first and second highest bids in a second price auction before 1pm (EST).
+        1. Managers may not make any claim to nor recieve FAAB returned as a difference between the first and second highest bids in a second price auction until 1pm (EST).
 1.  <a id="structure">League Structure</a>
     1.  There will be no divisions or conferences.
     1.  There will be 14 teams.

--- a/rules.md
+++ b/rules.md
@@ -8,6 +8,8 @@
         1.  [Ties](#ties)
     1.  [Draft](#draft)
     1.  [Waivers](#waivers)
+        1. [FAAB](#faab)
+        1. [Second Price Auctions](#second-price)
     1.  [League Structure](#structure)
     1.  [Schedule](#schedule)
         1.  [Regular Season](#regular-season)
@@ -37,6 +39,7 @@
         1.  The playoffs will have 7 teams, one with a bye, and take place on weeks 14 through 16.
         1.  The draft is on 9/4 at 9pm EDT.
         1.  We'll use FAAB to determine waiver claims and break ties with least recently used.
+        1. The winner of waiver wire auctions will pay the price that the second highest bidder bid.
         1.  There are no divisions.
         1.  League fee is $200.
         1.  Trades are allowed and the trade deadline is 11/11.
@@ -104,7 +107,7 @@
         1.  Determining draft order.
             1.  Draft order will be determined randomly by the commissioner, who will also provide proof that it was fairly chosen.
 1.  <a id="waivers">Waivers</a>
-    1.  Free Agent Acquisition Budget (FAAB)
+    1.  <a id="faab">Free Agent Acquisition Budget (FAAB)</a>
         1.  Each team will be allotted 10,000 FAAB immediately after the draft.
         1.  No additional FAAB will be introduced to the game at any point.
     1.  Each week teams will have a chance to pick up new players from the waiver wire, as long as they do not exceed the limit of their team size.
@@ -114,8 +117,9 @@
         1.  If two or more teams tie for the highest FAAB bid, the Continuing Rolling List tie-breaker method will be used, which is configured and determined by Yahoo! Sports.
     1.  Players may be dropped from a team at any time in order to make room for incoming players.
     1.  During a waiver request, managers may opt to conditionally drop a player if their request succeeds.
-    1. FAAB bids follow a Second Price Auction format.
-        1. The team that wins the FAAB auction that takes place on Yahoo wins the player and is forced to drop any other players if specificed on Yahoo, but only must pay the price of the second highest bid on the same player.
+    1. <a id="second-price">FAAB bids follow a Second Price Auction format.</a>
+        1. The team that wins the FAAB auction that takes place on Yahoo wins the player and is forced to drop any other players if specificed on Yahoo, but must only pay the price of the second highest bid on the same player.
+            1. If there is no second bidder, the second highest bid will be considered 0.
         1. The Yahoo interface will take the full FAAB from the highest bidder and the difference between this bid and the second highest bid will not be returned until the final game is played for the week, but no later than Tuesday at 1pm (EST).
         1. Managers may not make any claim to FAAB returned as a difference between the first and second highest bids in a second price auction before 1pm (EST).
 1.  <a id="structure">League Structure</a>

--- a/rules.md
+++ b/rules.md
@@ -114,6 +114,10 @@
         1.  If two or more teams tie for the highest FAAB bid, the Continuing Rolling List tie-breaker method will be used, which is configured and determined by Yahoo! Sports.
     1.  Players may be dropped from a team at any time in order to make room for incoming players.
     1.  During a waiver request, managers may opt to conditionally drop a player if their request succeeds.
+    1. FAAB bids follow a Second Price Auction format.
+        1. The team that wins the FAAB auction that takes place on Yahoo wins the player and is forced to drop any other players if specificed on Yahoo, but only must pay the price of the second highest bid on the same player.
+        1. The Yahoo interface will take the full FAAB from the highest bidder and the difference between this bid and the second highest bid will not be returned until the final game is played for the week, but no later than Tuesday at 1pm (EST).
+        1. Managers may not make any claim to FAAB returned as a difference between the first and second highest bids in a second price auction before 1pm (EST).
 1.  <a id="structure">League Structure</a>
     1.  There will be no divisions or conferences.
     1.  There will be 14 teams.


### PR DESCRIPTION
# Background

When bidding for players on the Waiver Wire (WW) in Fantasy Football, managers who win an auction pay the full amount of their bid. Pretty much all other silent auctions in the world use a [https://en.wikipedia.org/wiki/Generalized_second-price_auction](Second Price Auction) by which the highest bidder pays the price of the second highest bidder.

## Why it's better

- Under the current (first price) rules for auctions, managers are not incentivized to bid the highest amount they are willing to pay for a player. Instead, people are tempted to guess the bids of other players and try to out bid them by 1. This is because people want to avoid paying too mush more for a player than the second highest bidder. If we remove this fear, then people will only be incentivized to bid as high as they believe a player is worth, knowing they will get a refund if they bid much higher than the second highest bidder.

## Arguments against the haters

- People will say that there's now an advantage to people who want to bid very high on all players because they will continue to get refunds. This isn't an advantage, because it's a huge risk. If two players bid a very high amount on the same player, the lower of the high amounts will need to be paid to acquire the player.