### PR TITLE
2019 Rules Changes

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -187,7 +187,7 @@
         1.  Longest Winning Streak ($50)
             1.  The team that has the longest consecutive streak of matches won in the regular season, wins this contest.
             1.  Ties will go to the team with the longest 2nd winning streak, then 3rd, 4th, and so on.
-            1.  Remaining ties will go to the team that finishes the regular season with the higher seed.
+                1.  Remaining ties will go to the team that finishes the regular season with the higher seed.
         1.  Best week ($50)
             1.  Each team will have a chance to win best week every week.
             1.  The team with the highest scoring single week will win.
@@ -288,8 +288,6 @@
 1.  <a id="seeding">Seeding</a>
     1.  Regular Season
         1.  Seeding in the regular season will order teams from most to least games won.
-    1.  Post season
-        1.  The playoffs will be reseeded each round based on the regular season records for each of the remaining teams.
     1.  <a id="tie-breakers">Tie breakers</a>
         1.  Most ties in regular season
         1.  Best head-to-head record between teams who finished the regular season with the same record

--- a/rules.md
+++ b/rules.md
@@ -228,7 +228,7 @@
     1.  Any move may be objected by any manager within 24 hours after the move is made.
         1.  For trades this period starts when the trade is initiated; not processed.
     1.  Undoubtably bad moves
-        1.  A manager must not take any actions, including making moves and setting active players, such that at the time the action is iniated it undoubtably hurts the value of his or her team or hurts the chances of that team making the playoffs and finishing the regular season with the best possible seed.
+        1.  A manager must not take any actions, including making moves and setting active players, such that at the time the action is iniated it undoubtably diminishes the value of his or her team by reducing such team's chances of making the playoffs and finishing the regular season with the best possible seed.
             1.  Such actions may include, but are not limited to:
                 1.  Leaving roster positions empty when a healthy alternative was available on the bench or free agency (FA).
                 1.  Putting a player on active roster that has been long known to be not participating in the given week.

--- a/rules.md
+++ b/rules.md
@@ -272,6 +272,7 @@
     1.  League votes should be completed within 24 hours with each team manager voting yes (to make some change) or no (to keep things as they are).
     1.  Managers may abstain from a vote. In this case their vote will not count for or against the proposal.
     1.  Majority votes shall pass if at least half of the teams who didn't abstain, vote yes.
+        1. A majority vote shall pass immediately when this condition is met.
     1.  Unanimous votes shall pass if a majority of managers vote yes and all other managers abstain.
     1.  A unanimous vote will be required for any changes to the rules that may in anyway affect the chances for a manager to win a cash prize.
     1.  An objection shall constitute a yes vote to reverse the objected action.

--- a/rules.md
+++ b/rules.md
@@ -183,7 +183,7 @@
             1.  If two or more matchups tie for this prize, it will be divided further and rounding in all cases will favor teams with higher scores.
         1.  Best worst player ($50)
             1.  Each team will have a chance to win best worst player every week.
-            1.  In a single week, a team's "worst player" is the in-play player that scores the least points on a team that fills all roster positions for that week.
+            1.  In a single week, a team's "worst player" is the active player that scores the least points on a team that fills all roster positions for that week.
             1.  The best worst player award will go to the manager of the team who had the highest scoring worst player in any single week of the year.
             1.  Ties will be go to the team with the better 2nd worst player on the given week, then 3rd, 4th, and so on.
         1.  Best worst week ($50)

--- a/rules.md
+++ b/rules.md
@@ -43,7 +43,6 @@
         1.  There are no divisions.
         1.  League fee is $200.
         1.  Trades are allowed and the trade deadline is 11/11.
-        1.  FAAB may be used in trades with some restrictions.
         1.  Anything can be objected and a majority vote will determine the outcome.
         1.  Rules changes require a unanimous vote.
         1.  People who make the playoffs win at least $50 with 1st through 4th winning $1,000, $500, $250, and $100.
@@ -211,19 +210,6 @@
             1.  Tradebacks are when a manager makes a trade to gain a player that he or she once traded away.
             1.  Tradebacks are not strictly against the rules, but they are discouraged and are valid reasons for a manager to object despite not objecting to the original trade.
         1.  At least one player must be transferred by each team involved in a trade.
-        1.  Trades may include a transfer of FAAB from one team to another, with some exceptions, as a means to balance the trade.
-            1.  A team may not make a trade that results in either team holding more than 10,000 FAAB.
-            1.  No more than 2,500 FAAB may be transferred in a single trade.
-            1.  Trades involving FAAB must be proposed and accepted via the league message board.
-            1.  At no point may a manager have any combination of proposed trades, accepted trades or WW bids outstanding that could lead to a situation where his or her FAAB falls below 0 or in debt of the same player multiple times.
-        1.  If Yahoo! Sports can't accommodate a legal trade, the trade may be proposed in the league message board and the commissioner will manually make the moves at the end of the trade period.
-            1.  To propose a trade in the league message board, clearly and unambiguously state the team that the trade is proposed to along with all players and FAAB to be given and received.
-            1.  The trade will only be considered initialized when the manager that the trade was proposed to replies with the phrase "I accept" unconditionally and unnegated.
-            1.  In the case that a trade is proposed via the message board, objections may be initiated in the same thread.
-            1. Managers who propose trades via the message board may withdraw their proposal before such trade is accepted by unambiguously posting their intent to do so.
-            1. Managers may designate a time that their trade expires by posting it unambiguously in the message board.
-                1. This time may be changed by the proposing manager.
-                1. Times that don't include a timezone will be assumed to be Pacific Time.
 1.  <a id="objections">Objections</a>
     1.  Any move may be objected by any manager within 24 hours after the move is made.
         1.  For trades this period starts when the trade is initiated; not processed.

--- a/rules.md
+++ b/rules.md
@@ -23,6 +23,7 @@
     1.  [Voting](#voting)
     1.  [Seeding](#seeding)
         1.  [Tie Breakers](#tie-breakers)
+    1.  [Abandoned Teams](#abandoned-teams)
     1.  [Outside Influence](#outside-influence)
     1.  [Rules Not Stated](#rules-not-stated)
     1.  [Manager Responsibilities](#responsibilities)
@@ -42,13 +43,14 @@
         1.  We'll use FAAB to determine waiver claims and break ties with least recently used.
         1.  There are no divisions.
         1.  League fee is $200.
-        1.  Trades are allowed and the trade deadline is 11/11.
+        1.  Trades are allowed and the trade deadline will be the end of week 9.
         1.  Anything can be objected and a majority vote will determine the outcome.
         1.  Rules changes require a unanimous vote.
-        1.  People who make the playoffs win at least $50 with 1st through 4th winning $1,000, $500, $250, and $100.
-        1.  The team who scores the most points wins $200.
+        1.  People who make the playoffs win at least $50 with 1st through 3rd winning $1,000, $500, and $250.
+        1.  The teams to score 1st and 2nd place in the regular season will win $100 and $50.
+        1.  The team who scores the most points wins $150.
         1.  Starting on week 10, there are 4 weekly prizes of $100 each to be split between 2 teams each week.
-        1.  There are 4 other prizes of $50 each.
+        1.  There are 3 other prizes of $50 each.
         1.  People shouldn't create conflicts of interest with the league.
         1.  If a rule isn't defined well here, we fall back to Yahoo rules. If it's still not clear, we use a league vote.
         1.  Managers, especially the commissioner, should be competitive, but friendly.
@@ -168,10 +170,9 @@
             1.  1st place - $1,000
             1.  2nd place - $500
             1.  3rd place - $250
-            1.  4th place - $100
-            1.  5th through 7th place - $50 each (x3)
-        1.  Points ($200)
-            1.  Most points in the regular season - $200
+            1.  4th through 7th place - $50 each (x4)
+        1.  Points ($150)
+            1.  Most points in the regular season - $150
         1.  Weekly Prizes ($400 total)
             1.  For each of the final 4 weeks of the regular season, $100 will be awarded to the two teams faced off in the matchup that has the highest total score of both teams.
             1.  The $100 will be split among the two managers proportionally, rounding to the nearest $1 in favor of the winner.
@@ -185,10 +186,6 @@
             1.  At the end of the year, each team's "worst week" will be defined as the week that they scored their minimum score.
             1.  A manager will win best worst week if their team's worst week had a higher score than any other team.
             1.  Ties will go to the team with the better 2nd worst week, then 3rd, 4th, and so on.
-        1.  Longest Winning Streak ($50)
-            1.  The team that has the longest consecutive streak of matches won in the regular season, wins this contest.
-            1.  Ties will go to the team with the longest 2nd winning streak, then 3rd, 4th, and so on.
-                1.  Remaining ties will go to the team that finishes the regular season with the higher seed.
         1.  Best week ($50)
             1.  Each team will have a chance to win best week every week.
             1.  The team with the highest scoring single week will win.
@@ -210,6 +207,7 @@
             1.  Tradebacks are when a manager makes a trade to gain a player that he or she once traded away.
             1.  Tradebacks are not strictly against the rules, but they are discouraged and are valid reasons for a manager to object despite not objecting to the original trade.
         1.  At least one player must be transferred by each team involved in a trade.
+        1.  No two teams may trade with each other more than twice in the same season.
 1.  <a id="objections">Objections</a>
     1.  Any move may be objected by any manager within 24 hours after the move is made.
         1.  For trades this period starts when the trade is initiated; not processed.
@@ -281,6 +279,29 @@
         1.  Best head-to-head record between teams who finished the regular season with the same record
         1.  Most points in regular season
         1.  Coin flip
+1.  <a id="abandoned-teams">Amandoned Teams</a>
+    1.  Managers should keep an eye on their teams at least once a week, set their lineups in a way that they expect to win their games, and add and drop players to prepare to win more games.
+        1.  Managers should stay competitive even if they don't think they can improve their changces of making the playoffs or win prizes.
+    1.  Teams who fail to stay competitive may be declared abandoned and put through the abandoned team protocol if the following conditions are met.
+        1.  A manager in the league accuses a manager of neglecting their team.
+            1.  The accusing manager should describe the nature of the neglect.
+        1.  Such team has at the time of accusation:
+            1.  Won less games than the current 7 seed team.
+            1.  Taken action or inaction that has been reversed due to a successful objection.
+    1.  A supermajority league vote will take place when a team is placed on abandonment protocol.
+        1.  If this vote passes, the accused team will be placed on autopilot.
+        1.  For this vote to pass, at least 60% of the managers who aren't already on autopilot, must vote yes.
+    1.  When a team is placed on autopilot, the commissioner will set their line up each week in a predetermined fashion described here:
+        1.  At time of the start of each game, the starting roster will be set to the players on the team or available on FA that have the greatest Yahoo projection.
+        1.  Setting the roster may be done slightly after the game starts so that the projections lock in to their final value before the decision is made and so that any other team not on autopilot may have first dibs on any player.
+        1.  If a player must be dropped to accomodate a FA add, the dropped player will be chosen using the following method:
+            1.  If any of these exclusions, exclulde all players, then ignore them.
+            1.  If at any point, only one player is left, drop him.
+            1.  Once enough players are dropped to meet the roster size requirement, stop.
+            1.  Exclude dropping any players of any position that would prepare to leave the team in a future state of not being able to fill the team with players projected more than 0 points.
+            1.  Exclude dropping any players on Yahoo's can't cut list.
+            1.  Drop the remaining player with the smallest maximum projected weekly score left of the weeks leading to week 13 in the regular season and 16 in the playoffs.
+    1.  The comissioner may at any time call a majority league vote to take a team off autopilot.
 1.  <a id="outside-influence">Outside influence</a>
     1.  No external value to the league, including monetary value, may be exchanged between managers for moves or any other manager decision.
     1.  No side bets or games of chance shall be wagered by a manager, aside from those outlined by these rules, that rewards that manager for making a decision that reduces his or her team's chance of winning a match up.

--- a/rules.md
+++ b/rules.md
@@ -241,6 +241,7 @@
                 1.  Pulling (or not pulling) a player from active roster after the manager's team has gained a lead that would be at risk if the player scored negative points.
                 1.  In rare cases, leaving a roster position empty because no alternative exists on the bench and no benched player is worth dropping.
             1.  A successful objection regarding a roster decision to activate a specific player shall always result in that player being substituted for the player on the bench with the highest projection who's capable of filling that position. In the case that no player is available, a move to pick up a suitable player from FA may be forced.
+            1.  A successful objection to a move that results in a player add shall always result in such player being placed on the waiver wire, whether the player came from waiver wire or free agency, and the waiver date should be the next day if the objection vote passes before 9pm (EST) and in two days otherwise.
     1.  Waiver abuse
         1.  If a player is suspected of dropping and picking up players from FA for the sole significant purpose of moving players to waivers, any moves made to accomplish this may be objected.
         1.  An exception may be made if the league determines by a majority vote that the player was scrambling "last-minute" to assemble a viable scoring team with incomplete information.

--- a/rules.md
+++ b/rules.md
@@ -274,14 +274,14 @@
     1.  Majority votes shall pass if at least half of the teams who didn't abstain, vote yes.
     1.  Unanimous votes shall pass if a majority of managers vote yes and all other managers abstain.
     1.  A unanimous vote will be required for any changes to the rules that may in anyway affect the chances for a manager to win a cash prize.
-    1. An objection shall constitute a yes vote to reverse the objected action.
-    1. All votes must be cast publicly, in the message board, and by the manager who's vote it is.
+    1.  An objection shall constitute a yes vote to reverse the objected action.
+    1.  All votes must be cast publicly, in the message board, unconditionally, unambiguously, and by the manager who's opinion they represent.
     1.  A majority vote will be required for:
         1.  Objections.
         1.  Disambiguating any rules.
             1.  The commissioner will determine upon request whether the rule is ambiguous or not. Non-ambiguous rules will only be changed upon unanimous vote.
         1.  Replacing the commissioner.
-        1.  Anything else that doesn't require a unanimous vote.
+        1.  Anything else that doesn't explicitly require a unanimous vote.
     1.  Managers are disqualified from voting on a particular issue if they are directly involved with what is being voted upon.
         1.  Commissioner may make initial ruling, but will not participate in the league vote if he is directly involved.
         1.  Managers directly involved include but are not limited to

--- a/rules.md
+++ b/rules.md
@@ -249,10 +249,10 @@
         1.  Contacting the commissioner and stating the manager's intention to object and receiving an acknowledgement of such intention.
             1. Commissioner gives no guarentee that he will respond promptly. For this reason, it's recommended that managers use the message board when they'd like a fast decision.
     1.  Whenever an objection is initiated, the commissioner will clearly explain the situation publically to the league and outline the procedure for resolving it.
-    1.  When an objection is initiated, each manager in the league will have whichever is later of 24 hours after the time the objection is initiated or 48 hours after the time the objected action occurred to perform a majority league vote to determine the outcome of the objection.
+    1.  When an objection is initiated, each manager in the league will have until whichever is later of 24 hours after the time the objection is initiated or 48 hours after the time the objected action occurred to perform a majority league vote to determine the outcome of the objection.
     1.  If an objection vote passes, the commissioner will do his best to reverse the actions that have been done as a result of the objection.
         1.  In some cases, this may include reversing other actions by other teams, if they are determined by a majority league vote to have been responses to the original objected action.
-        1.  In the case that multiple actions need to be reversed, they will be determined in ascending chronological order.
+        1.  In the case that multiple actions need to be reversed, they will be determined in forward chronological order.
     1.  <a id="suspending-moves">In order to prevent multiple objections, the commissioner may suspend certain actions, including but not limited to moves, during a league vote until the vote is complete.</a>
         1.  The commissioner will do his best to act quickly to finish an objection vote, in an attempt to avoid suspending moves.
         1.  In the event moves are suspended, managers may request to conditionally, based on the outcome of the objection vote, make a move.

--- a/rules.md
+++ b/rules.md
@@ -98,8 +98,8 @@
             1. If the highest bench players are tied, the winner will be determined by the next highest bench players. This process should repeat through the entire bench until a win is determined.
             1. If there is still a tie, the win will go to the team that ended the regular season with the better seed.
 1.  <a id="draft">Draft</a>
-    1.  Draft day
-        1.  The draft will start at 9:00 pm EST and run until all teams have drafted a full roster.
+    1.  Date and time
+        1.  TBD
     1.  Each manager will have up to 90 seconds to draft a single player to his/her team for each round.
     1.  There will be 14 rounds of the draft; one for each player on the team.
     1.  Order

--- a/rules.md
+++ b/rules.md
@@ -103,7 +103,7 @@
     1.  Each manager will have up to 90 seconds to draft a single player to his/her team for each round.
     1.  There will be 14 rounds of the draft; one for each player on the team.
     1.  Order
-        1.  Draft order will be determined after a majority of managers have accepted the rules, but no later than August 26, 2017.
+        1.  Draft order will be determined after all managers have accepted and committed to the rules.
         1.  Draft order will be serpentine.
             1.  Each of the odd numbered rounds starting with the first round will draft in the determined draft order.
             1.  Each of the even numbered rounds will draft in reverse order.
@@ -154,6 +154,8 @@
                     1.  Winner is 3rd place
                     1.  Loser is 4th place
         1.  For the sake of prizes, the 3 losing teams in week 14 will be considered 5th, 6th, and 7th place in no particular order.
+        1. Teams who don't qualify for the playoffs will be locked from making player moves including adds and drops, but will still be able to set their lineups.
+            1. The losing teams during week 14 will also be locked from making player moves.
 1.  <a id="money">Money</a>
     1.  <a id="fees">League Fees</a>
         1.  Payment

--- a/rules.md
+++ b/rules.md
@@ -22,6 +22,7 @@
         1.  [Suspending Moves](#suspending-moves)
     1.  [Voting](#voting)
     1.  [Seeding](#seeding)
+        1.  [Tie Breakers](#tie-breakers)
     1.  [Outside Influence](#outside-influence)
     1.  [Rules Not Stated](#rules-not-stated)
     1.  [Manager Responsibilities](#responsibilities)
@@ -116,7 +117,7 @@
     1.  When placing a request for a waiver wire pick up, a team must enter a bid in FAAB, which may be any integer inclusively between 0 and their remaining budget.
         1.  Each player sought via a waiver request will be awarded to the team that placed the highest FAAB and the FAAB will be deducted from that team's FAAB budget.
         1.  FAAB will not be deducted for losing bids.
-        1.  If two or more teams tie for the highest FAAB bid, the Continuing Rolling List tie-breaker method will be used, which is configured and determined by Yahoo! Sports.
+        1.  If two or more teams tie for the highest FAAB bid, the Continuing Rolling List tie breaker method will be used, which is configured and determined by Yahoo! Sports.
     1.  Players may be dropped from a team at any time in order to make room for incoming players.
     1.  During a waiver request, managers may opt to conditionally drop a player if their request succeeds.
 1.  <a id="structure">League Structure</a>
@@ -178,7 +179,7 @@
             1.  Each team will have a chance to win best worst player every week.
             1.  In a single week, a team's "worst player" is the active player that scores the least points on a team that fills all roster positions for that week.
             1.  The best worst player award will go to the manager of the team who had the highest scoring worst player in any single week of the year.
-            1.  Ties will be go to the team with the better 2nd worst player on the given week, then 3rd, 4th, and so on.
+            1.  Ties will go to the team with the better 2nd worst player on the given week, then 3rd, 4th, and so on.
         1.  Best worst week ($50)
             1.  At the end of the year, each team's "worst week" will be defined as the week that they scored their minimum score.
             1.  A manager will win best worst week if their team's worst week had a higher score than any other team.
@@ -289,14 +290,11 @@
         1.  Seeding in the regular season will order teams from most to least games won.
     1.  Post season
         1.  The playoffs will be reseeded each round based on the regular season records for each of the remaining teams.
-    1.  Tie breakers (2 teams)
+    1.  <a id="tie-breakers">Tie breakers</a>
         1.  Most ties in regular season
-        1.  Best head-to-head record between tied teams
+        1.  Best head-to-head record between teams who finished the regular season with the same record
         1.  Most points in regular season
         1.  Coin flip
-    1.  Tie breakers (3+ teams)
-        1.  Determine highest rank by scoring each of the 2-team tie breaking contests in order. (i.e. most ties, then best 3+ way head-to-head, etc.)
-        1.  As soon as a team wins tie breaking procedures among the group of tied teams, tie breaking procedures start over with the remaining teams vying for the next highest seed.
 1.  <a id="outside-influence">Outside influence</a>
     1.  No external value to the league, including monetary value, may be exchanged between managers for moves or any other manager decision.
     1.  No side bets or games of chance shall be wagered by a manager, aside from those outlined by these rules, that rewards that manager for making a decision that reduces his or her team's chance of winning a match up.

--- a/rules.md
+++ b/rules.md
@@ -277,6 +277,7 @@
     1.  A unanimous vote will be required for any changes to the rules that may in anyway affect the chances for a manager to win a cash prize.
     1.  An objection shall constitute a yes vote to reverse the objected action.
     1.  All votes must be cast publicly, in the message board, unconditionally, unambiguously, and by the manager who's opinion they represent.
+        1.  Managers may change their vote at any time by casting a new vote that fit this criteria.
     1.  A majority vote will be required for:
         1.  Objections.
         1.  Disambiguating any rules.

--- a/rules.md
+++ b/rules.md
@@ -135,9 +135,9 @@
         1.  The highest seed in the regular season will receive a bye on week 14.
         1.  Playoffs will take place during weeks 14 through 16.
             1.  Week 14 matchups
-                1.  Seed 2 chooses a team among seeds 4 though 7, that they will play against.
+                1.  Seed 2 chooses a team among seeds 3 though 7, that they will play against.
                     1. This choice must be made on or before 1pm (EST) the Tuesday before the games or the choice will default to the highest available seed number.
-                1.  Seed 3 chooses a team among seeds 4 though 7 excluding the team chosen by seed 2, that they will play against.
+                1.  The lowest remaining seed chooses a team among seeds 5 though 7, excluding the team chosen by seed 2, that they will play against.
                     1. This choice must be made on or before 7pm (EST) the Tuesday before the games or the choice will default to the highest available seed number.
                 1.  The remaining two teams between seeds 4 and 7 play against each other.
             1.  Week 15 matchups

--- a/rules.md
+++ b/rules.md
@@ -231,14 +231,16 @@
 1.  <a id="objections">Objections</a>
     1.  Any move may be objected by any manager within 24 hours after the move is made.
         1.  For trades this period starts when the trade is initiated; not processed.
-    1.  Setting a roster in a way that is obviously not intended to beat the other team may be objected.
-        1.  This includes, but is not limited to:
-            1.  Leaving roster positions empty when a healthy alternative was available on the bench or free agency (FA).
-            1.  Putting a player on active roster that has been long known to be not participating in the given week.
-        1.  Exceptions may include:
-            1.  Pulling (or not pulling) a player from active roster after the manager's team has gained a lead that would be at risk if the player scored negative points.
-            1.  In rare cases, leaving a roster position empty because no alternative exists on the bench and no benched player is worth dropping.
-        1.  A successful objection regarding a roster decision to play a specific player shall always result in that player being substituted for the player on the bench with the highest projection who's capable of filling that position. In the case that no player is available, a move to pick up a suitable player from FA may be forced.
+    1.  Undoubtably bad moves
+        1.  A manager must not take any actions, including making moves and setting active players, such that at the time the action is iniated it undoubtably hurts the value of his or her team or hurts the chances of that team making the playoffs and finishing the regular season with the best possible seed.
+            1.  Such actions may include, but are not limited to:
+                1.  Leaving roster positions empty when a healthy alternative was available on the bench or free agency (FA).
+                1.  Putting a player on active roster that has been long known to be not participating in the given week.
+                1.  Dropping an exceptionally valuable player when a significantly lesser valued alternative player was available to be dropped.
+            1.  Exceptions may include:
+                1.  Pulling (or not pulling) a player from active roster after the manager's team has gained a lead that would be at risk if the player scored negative points.
+                1.  In rare cases, leaving a roster position empty because no alternative exists on the bench and no benched player is worth dropping.
+            1.  A successful objection regarding a roster decision to activate a specific player shall always result in that player being substituted for the player on the bench with the highest projection who's capable of filling that position. In the case that no player is available, a move to pick up a suitable player from FA may be forced.
     1.  Waiver abuse
         1.  If a player is suspected of dropping and picking up players from FA for the sole significant purpose of moving players to waivers, any moves made to accomplish this may be objected.
         1.  An exception may be made if the league determines by a majority vote that the player was scrambling "last-minute" to assemble a viable scoring team with incomplete information.

--- a/rules.md
+++ b/rules.md
@@ -274,7 +274,7 @@
     1.  A unanimous vote will be required for any changes to the rules that may in anyway affect the chances for a manager to win a cash prize.
     1.  An objection shall constitute a yes vote to reverse the objected action.
     1.  All votes must be cast publicly, in the message board, unconditionally, unambiguously, and by the manager who's opinion they represent.
-        1.  Managers may change their vote at any time by casting a new vote that fit this criteria.
+        1.  Managers may change their vote at any time by casting a new vote that fits this criteria. The new vote will replace the old vote.
     1.  A majority vote will be required for:
         1.  Objections.
         1.  Disambiguating any rules.

--- a/rules.md
+++ b/rules.md
@@ -9,7 +9,6 @@
     1.  [Draft](#draft)
     1.  [Waivers](#waivers)
         1. [FAAB](#faab)
-        1. [Second Price Auctions](#second-price)
     1.  [League Structure](#structure)
     1.  [Schedule](#schedule)
         1.  [Regular Season](#regular-season)
@@ -40,7 +39,6 @@
         1.  The playoffs will have 7 teams, one with a bye, and take place on weeks 14 through 16.
         1.  The draft time has yet to be determined.
         1.  We'll use FAAB to determine waiver claims and break ties with least recently used.
-        1.  The winner of waiver wire auctions will pay the price that the second highest bidder bid.
         1.  There are no divisions.
         1.  League fee is $200.
         1.  Trades are allowed and the trade deadline is 11/11.
@@ -121,11 +119,6 @@
         1.  If two or more teams tie for the highest FAAB bid, the Continuing Rolling List tie-breaker method will be used, which is configured and determined by Yahoo! Sports.
     1.  Players may be dropped from a team at any time in order to make room for incoming players.
     1.  During a waiver request, managers may opt to conditionally drop a player if their request succeeds.
-    1. <a id="second-price">FAAB bids follow a Second Price Auction format.</a>
-        1. The team that wins the FAAB auction that takes place on Yahoo wins the player and is forced to drop any other players if specificed on Yahoo, but must only pay the price of the second highest bid on the same player.
-            1. If there is no second bidder, the second highest bid will be considered 0.
-        1. The Yahoo interface will take the full FAAB from the highest bidder and the difference between this bid and the second highest bid will not be returned until the final game is played for the week, but no later than Tuesday at 1pm (EST).
-        1. Managers may not make any claim to nor recieve FAAB returned as a difference between the first and second highest bids in a second price auction until the end of the aforementioned period of time.
 1.  <a id="structure">League Structure</a>
     1.  There will be no divisions or conferences.
     1.  There will be 14 teams.


### PR DESCRIPTION
I'm hoping to get unanimous consent on these rules changes which I believe are uncontroversial.

Here's a summary of the changes:

1. Spelling and grammar fixes.
1. Remove second price auctions.
1. Remove an old rule about playoffs that was made obsolete by our new playoff seeding rules.
1. Remove FAAB trades and by extension message board trades. All trades now go through the standard interface.
1. The Doug Baldwin rule - adding some guidance around what roster moves should and shouldn't be objected to.
1. The Tim Young rule - blocking teams eliminated from competing with super bowl contenders in WW and FA.
1. Clarify that voting can not be conditional or vague.
1. Allow people to change their votes within the 24 hour voting period as they uncover more information.
1. Make voting faster by ending it early when enough yeses or noes come in to determine the outcome.
1. Prevent a late night vote from causing changes to WW or FA while people are sleeping
1. Tweak playoff seeding rules to make 2 seed better than 3 seed, 3 better then 4, and 4 better than the rest.