### PR TITLE
Season 12

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -154,13 +154,15 @@
             1.  Managers will have a chance to review the rules before committing to the league.
                 1.  If 12 managers do not commit, the initial payment will be refunded.
     1.  <a id="payouts">Payouts</a>
-        1.  Playoffs ($1,850 total)
-            1.  1st place - $1,000
-            1.  2nd place - $400
+        1.  Playoffs ($1,900 total)
+            1.  1st place - $1,100
+            1.  2nd place - $450
             1.  3rd place - $350
             1.  4th place - $100
-        1.  Points ($200)
-            1.  Most points in the regular season - $200
+        1.  Losers bracket ($100)
+            1.  Winner of the losers bracket will win $100.
+        1.  Points ($100)
+            1.  Most points in the regular season - $100
         1.  Best worst player ($50)
             1.  Each team will have a chance to win best worst player every week.
             1.  In a single week, a team's "worst player" is the active player that scores the least points on a team that fills all roster positions for that week.
@@ -179,13 +181,8 @@
             1.  At the end of the regular season, the team with the most points will win.
             1.  Ties will go to the team who scored the most points in the weeks that their earned their point for this prize, or a coin flip if still tied.
         1.  Weekly prizes ($400)
-            1.  Each team in the top scoring matchup during weeks 10, 11, 12, and 13 will win $50 each.
+            1.  During weeks 10-13, each team in the top scoring matchup will win $50 each week.
             1.  If there is a tie for highest scoring matchup, the prize will be split among all tied teams.
-        1.  Most FAB ($50)
-            1.  The team that makes the playoffs with the most FAB remaining will win $50.
-            1.  Ties will be broken by highest waiver priority (same as FAB tie-breaking for player pickups).
-        1.  Losers bracket ($100)
-            1.  Winner of the losers bracket will win $100.
         1.  All prizes will be paid out no later than the real NFL Super Bowl.
         1.  After week 15, any players remaining in the playoffs may renegotiate the prizes for 1st through 4th place provided that the new prize distribution is proposed to the commissioner by the highest seeded remaining manager and all other remaining managers accept.
 1.  <a id="moves">Moves</a>

--- a/rules.md
+++ b/rules.md
@@ -48,7 +48,7 @@
         1.  The winner of the losers bracket wins $100.
         1.  People shouldn't create conflicts of interest with the league.
         1.  If a rule isn't defined well here, we fall back to Yahoo rules. If it's still not clear, we use a league vote.
-        1.  All times in these rules are Eastern Standard Time.
+        1.  All times in these rules are Eastern Time.
         1.  Managers, especially the commissioner, should be competitive, but friendly.
 1.  <a id="teams">Yahoo! Sports Settings and Rules</a>
     1. Many settings are configured on the Yahoo! Sports Fantasy Football platform and have been removed from this rules document. The settings on the app are the source of truth for these. These settings include, but are not limited to the following:
@@ -112,12 +112,13 @@
         1.  Playoffs will take place during weeks 14 through 16.
             1.  Week 14 matchups
                 1.  Seed 2 chooses a team among seeds 3 through 7, that they will play against.
-                    1. This choice must be made on or before 1pm (EST) the Tuesday before the games or the choice will default to the highest available seed number.
-                1.  The best remaining seed (lowest number among 3-7, excluding seed 2's choice) chooses their opponent from the remaining teams.
+                    1. This choice must be made on or before 1pm (ET) the Tuesday before the games or the choice will default to the highest available seed number.
+                1.  The best remaining seed (seed 3 or 4, whichever was not chosen by seed 2) chooses their opponent from the remaining teams.
+                    1. This choice must be made on or before 4pm (ET) the Tuesday before the games or the choice will default to the highest available seed number.
                 1.  The final two remaining teams play each other.
             1.  Week 15 matchups
                 1.  Seed 1 chooses a team among the three winners of week 14 to play against.
-                    1. This choice must be made on or before 7pm (EST) the Tuesday before the games or the choice will default to the highest available seed number.
+                    1. This choice must be made on or before 1pm (ET) the Tuesday before the games or the choice will default to the highest available seed number.
                 1.  The remaining two winners of week 14 play against each other.
             1.  Week 16 matchups
                 1.  Superbowl
@@ -131,6 +132,11 @@
         1.  Losers Bracket
             1.  A 7 team losers bracket will be set up for teams that do not make the playoffs (seeds 8-14).
             1.  Losers bracket seeding will use the same tie-breaking method as regular season seeding, except total wins and ties will be ignored and the primary seeding method will be winning/losing streaks.
+            1.  Losers bracket opponent selection follows the same rules as the main playoffs:
+                1.  Week 14: Seed 9 chooses first (by 1pm ET Tuesday), then the best remaining seed among 10-14 chooses (by 4pm ET Tuesday).
+                1.  Week 15: Seed 8 chooses among the winners (by 1pm ET Tuesday).
+        1.  Playoff choice delays
+            1.  If the NFL or Yahoo causes a matchup to be incomplete by the time playoff opponent choices are due, or Yahoo delays waivers, then the choice deadline will be delayed until the first day after the matchups are complete or until the last day before the new waiver date.
         1.  FAB bonuses
             1.  Each team that makes the playoffs will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 14.
             1.  Teams in the Superbowl will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 16.

--- a/rules.md
+++ b/rules.md
@@ -49,14 +49,13 @@
             1.  Do not stop trying! The weekly prizes, regular season prizes, and $100 for losers bracket mean you can still win your money back.
         1.  Trades are allowed and the trade deadline is week 10.
         1.  Trades will process immediately by Yahoo, but any manager may object within 24 hours and the trade will be reversed if a majority votes against it.
-        1.  We use longest [win-streak](#winning-streaks) to end the year as a tie-breaking method for the playoffs and as the primary seeding method for the losers bracket to make sure the final weeks are always competitive.
+        1.  We use [longest win-streak](#winning-streaks) to end the year as a tie-breaking method for the playoffs and as the primary seeding method for the losers bracket to make sure the final weeks are always competitive.
         1.  Top seeded playoff teams [choose their opponents](#choosing-opponents) each week.
-        1.  Playoff teams receive [FAB bonuses](#playoffs) during the playoffs.
+        1.  Playoff teams receive [FAB bonuses](#playoffs) during the playoffs so that they maintain waiver priority over losers bracket.
         1.  Teams get locked in the post-season when out of contention for top 4 or losers bracket winner.
-        1.  If a rule isn't defined here, we fall back on Yahoo rules.
-        1.  If a rule is ambiguous, we have a league vote.
+        1.  If a rule isn't defined here, we fall back on Yahoo's rules.
+        1.  If a rule is still ambiguous, we have a league vote.
         1.  All times are Eastern Time (ET).
-        1.  Managers, especially the commissioner, should be competitive, but friendly.
 1.  <a id="draft">Draft</a>
     1.  Live snake draft on Monday, September 1 at 8:45pm ET.
     1.  Draft order will be determined after all teams commit to the league by paying their league dues and at least 1 hour before the draft.

--- a/rules.md
+++ b/rules.md
@@ -11,9 +11,9 @@
     1.  [Moves](#moves)
         1.  [Trades](#trades)
     1.  [Objections](#objections)
-        1.  [Undoubtably bad moves](#undoubtably) (the most controversial rule we have)
+        1.  [Undoubtably bad moves](#undoubtably) (the most controversial rule we have, but it's important)
         1.  [Suspending Moves](#suspending-moves)
-    1.  [Voting](#voting)
+    1.  [Voting and Objections](#voting)
     1.  [Seeding](#seeding)
         1.  [Tie Breakers](#tie-breakers)
         1.  [Ties](#ties)
@@ -24,101 +24,64 @@
     1.  [Commissioner Responsibilities](#commissioner)
     1.  [Incomplete NFL Season](#incomplete)
     1.  [Timezones](#timezones)
-1.  <a id="tldr">TLDR</a>
+1.  <a id="tldr">Summary</a>
     1.  Disclaimer
-        1.  TLDR stands for "too long didn't read".
-        1.  This section is intended to be a brief summary of the rules.
+        1.  This section provides a brief summary for those who don't need all the details.
         1.  If a conflict exists between this section and another section below, this section will be invalid.
-    1.  Summary
-        1.  There are 14 teams.
-        1.  Each team has 14 players + 1 IR.
-        1.  A team can play 1 QB, 2 WR, 2 RB, 1 TE, 1 FLEX, 1 K, and 1 DST each week.
-        1.  The regular season is 13 weeks, with each team playing every other team exactly once.
-        1.  The playoffs will have 8 teams, four will get a bye, and take place on weeks 14 through 17.
-        1.  The draft time is on the Sunday before the first game each season at 8pm.
-        1.  We'll use FAB to determine waiver claims and break ties with least recently used.
+    1.  League Settings
+        1.  14 teams, no keepers.
+        1.  Live snake draft on Monday, September 1 at 8:45pm ET.
+        1.  Roster: 1 QB, 2 WR, 2 RB, 1 TE, 1 FLEX, 1 K, 1 DST, 4 bench, 2 IR.
+        1.  Regular season: 13 weeks, each team plays every other team once.
+        1.  Playoffs: 7 teams over 3 weeks (14-16), with 1 bye.
+        1.  Trade deadline is week 10.
+        1.  FAB waivers with least recently used tie-breaking.
+        1.  Decimal and negative scoring enabled.
+        1.  All other league and scoring settings can be found on the [Yahoo Fantasy settings page](https://football.fantasysports.yahoo.com/f1/456171/settings).
+    1.  Money Rules
         1.  League fee is $200.
-        1.  Trades are allowed and the trade deadline will be the Saturday of week 12.
-        1.  Trades will process immediately by Yahoo, but any manager may object and a majority vote will determine whether the trade is overturned.
-        1.  In this league, it is against the rules to stop trying. If you make an "[undoubtably bad move](#undoubtably)", your line up will be set for you and your team may be put on autopilot.
-        1.  Only the top 4 playoff finishers win money: 1st ($1,000), 2nd ($400), 3rd ($350), and 4th ($100).
-        1.  The team who scores the most points wins $200.
-        1.  There are 4 other prizes of $50 each, plus $50 for most FAB remaining among playoff teams.
-        1.  Weekly prizes: $50 for each team in the top scoring matchup during weeks 10, 11, 12, and 13.
+        1.  Playoff finishers win money: 1st ($1,100), 2nd ($450), 3rd ($350), and 4th ($100).
+        1.  The team who scores the most points wins $100.
+        1.  4 other regular season prizes of $50 each.
+        1.  Weekly prizes: $50 for each team in the top scoring matchup during weeks 10-13.
         1.  The winner of the losers bracket wins $100.
-        1.  People shouldn't create conflicts of interest with the league.
-        1.  If a rule isn't defined well here, we fall back to Yahoo rules. If it's still not clear, we use a league vote.
-        1.  All times in these rules are Eastern Time.
+        1.  Teams should not create conflicts of interest with the league (e.g., betting that your team will lose or your players will do poorly).
+    1.  Additional Rules
+        1.  It's against the rules to stop trying. If you make one or more "[undoubtably bad moves](#undoubtably)", the moves may be reversed, your lineup may be set for you, and your team may be put on autopilot.
+            1.  Do not stop trying! The weekly prizes, regular season prizes, and $100 for losers bracket mean you can still win your money back.
+        1.  Trades are allowed and the trade deadline is week 10.
+        1.  Trades will process immediately by Yahoo, but any manager may object within 24 hours and the trade will be reversed if a majority votes against it.
+        1.  We use longest [win-streak](#winning-streaks) to end the year as a tie-breaking method for the playoffs and as the primary seeding method for the losers bracket to make sure the final weeks are always competitive.
+        1.  Top seeded playoff teams choose their [opponents](#choosing-opponents) each week.
+        1.  Playoff teams receive [FAB bonuses](#playoffs) during the playoffs.
+        1.  Teams get locked in the post-season when out of contention for top 4 or losers bracket winner.
+        1.  If a rule isn't defined here, we fall back on Yahoo rules.
+        1.  If a rule is ambiguous, we have a league vote.
+        1.  All times are Eastern Time (ET).
         1.  Managers, especially the commissioner, should be competitive, but friendly.
-1.  <a id="teams">Yahoo! Sports Settings and Rules</a>
-    1. Many settings are configured on the Yahoo! Sports Fantasy Football platform and have been removed from this rules document. The settings on the app are the source of truth for these. These settings include, but are not limited to the following:
-        1. Scoring settings
-        1. Roster positions
-        1. Injury designations
-        1. Player positions.
-    1. Yahoo's platform will also be the final decision maker for any game mechanic within their control that doesn't have an explicit exception in this rules document. Examples of this include, but are not limited to:
-        1. When games are canceled or postponed and which week they count for.
-        1. When waiver dates are modified to accomodate postponed games.
-        1. When injury designations or player positions change.
-        1. How rosters may be set.
-        1. What moves are valid to make.
-        1. How waivers work.
-1.  <a id="managers">Team Managers</a>
-    1.  Each team must have one manager. Each manager must have one team.
-    1.  Managers are responsible for making all decisions pertaining to his or her team including but not limited to:
-        1.  League Fees
-        1.  Draft Picks
-        1.  Setting Roster
-        1.  Proposing and Accepting Trades
-        1.  Objections
-        1.  Voting
-        1.  Keeper Elections
-    1.  Teams may have as many other advisors helping them make decisions, but the manager must make all final decisions.
-    1.  Managers may give advice to other managers.
-    1.  Teams are transferable in that they can be given, sold, or auctioned to new managers as long as no two managers own the same team.
 1.  <a id="draft">Draft</a>
-    1.  Date and time
-        1.  The draft time will be the Sunday before the first game of the season at 8pm.
-            1.  This date will be determined on August 1 as the day the NFL projects the first game will be played.
-    1.  Order
-        1.  Draft order will be determined by manager's choice in an order determined by the previous year's standings.
-            1. Choice order and deadlines
-                1. 7th place from previous year may choose any draft position by 10am, 4 days before the draft.
-                1. 8th place from previous year may choose any remaining draft position by 12pm, 4 days before the draft.
-                1. 9th place from previous year may choose any remaining draft position by 2pm, 4 days before the draft.
-                1. 10th place from previous year may choose any remaining draft position by 4pm, 4 days before the draft.
-                1. 11th place from previous year may choose any remaining draft position by 6pm, 4 days before the draft.
-                1. 12th place from previous year may choose any remaining draft position by 8pm, 4 days before the draft.
-                1. 5th place from previous year may choose any remaining draft position by 10am, 3 days before the draft.
-                1. 6th place from previous year may choose any remaining draft position by 12pm, 3 days before the draft.
-                1. 4th place from previous year may choose any remaining draft position by 2pm, 3 days before the draft.
-                1. 3rd place from previous year may choose any remaining draft position by 4pm, 3 days before the draft.
-                1. 2nd place from previous year may choose any remaining draft position by 6pm, 3 days before the draft.
-                1. 1st place from previous year will be assigned the only remaining draft position.
-            1. Setting preferences and defaults
-                1. Any manager may post a list of draft position preferences publicly to the league at anytime and the most preferred draft position in their preference list will be automatically selected for them.
-                1. If a manager does not choose their draft position by their draft position by their assiigned deadline, the lowest remaining draft position will be assigned.
+    1.  Live snake draft on Monday, September 1 at 8:45pm ET.
+    1.  Draft order will be determined after all teams commit to the league by paying their league dues and at least 1 hour before the draft.
 1.  <a id="schedule">Schedule</a>
     1.  <a id="regular-season">Regular Season</a>
         1.  The schedule will be randomly determined before draft picks are selected at the start of the season.
-            1. Commissioner will use the best tools reasonably available to randomize the schedule and do his best to show that it was truly random.
         1.  The following criteria will be enforced when randomizing the schedule:
             1.  There will be 13 games for each team in the regular season, corresponding to the first 13 weeks of the NFL regular season.
             1.  Each team will play against every other team exactly once.
     1.  <a id="playoffs">Playoffs</a>
         1.  7 Teams will qualify for the playoffs.
             1.  Yahoo sometimes doesn't support our playoff seeding rules, so the real playoff schedule will be announced by the commissioner each week.
-        1.  The highest seed in the regular season will receive a bye on week 14.
-        1.  Playoffs will take place during weeks 14 through 16.
+        1.  The 1 seed will receive a bye on week 14.
+        1.  <a id="choosing-opponents">Playoffs will take place during weeks 14 through 16.</a>
             1.  Week 14 matchups
                 1.  Seed 2 chooses a team among seeds 3 through 7, that they will play against.
-                    1. This choice must be made on or before 1pm (ET) the Tuesday before the games or the choice will default to the highest available seed number.
-                1.  The best remaining seed (seed 3 or 4, whichever was not chosen by seed 2) chooses their opponent from the remaining teams.
-                    1. This choice must be made on or before 4pm (ET) the Tuesday before the games or the choice will default to the highest available seed number.
+                    1. This choice must be made on or before 1pm (ET) the Tuesday before the games or the choice will default to the bottom seed.
+                1.  The top remaining seed (seed 3 or 4, whichever was not chosen by seed 2) chooses their opponent from the remaining teams.
+                    1. This choice must be made on or before 4pm (ET) the Tuesday before the games or the choice will default to the bottom seed.
                 1.  The final two remaining teams play each other.
             1.  Week 15 matchups
                 1.  Seed 1 chooses a team among the three winners of week 14 to play against.
-                    1. This choice must be made on or before 1pm (ET) the Tuesday before the games or the choice will default to the highest available seed number.
+                    1. This choice must be made on or before 1pm (ET) the Tuesday before the games or the choice will default to the bottom seed.
                 1.  The remaining two winners of week 14 play against each other.
             1.  Week 16 matchups
                 1.  Superbowl
@@ -131,9 +94,9 @@
                     1.  Loser is 4th place
         1.  Losers Bracket
             1.  A 7 team losers bracket will be set up for teams that do not make the playoffs (seeds 8-14).
-            1.  Losers bracket seeding will use the same tie-breaking method as regular season seeding, except total wins and ties will be ignored and the primary seeding method will be winning/losing streaks.
+            1.  Losers bracket seeding will use the same tie-breaking method as regular season seeding, except total wins and ties will be ignored and the primary seeding method will be [winning/losing streaks](#winning-streaks).
             1.  Losers bracket opponent selection follows the same rules as the main playoffs:
-                1.  Week 14: Seed 9 chooses first (by 1pm ET Tuesday), then the best remaining seed among 10-14 chooses (by 4pm ET Tuesday).
+                1.  Week 14: Seed 9 chooses first (by 1pm ET Tuesday), then the top remaining seed among 10-14 chooses (by 4pm ET Tuesday).
                 1.  Week 15: Seed 8 chooses among the winners (by 1pm ET Tuesday).
         1.  Playoff choice delays
             1.  If the NFL or Yahoo causes a matchup to be incomplete by the time playoff opponent choices are due, or Yahoo delays waivers, then the choice deadline will be delayed until the first day after the matchups are complete or until the last day before the new waiver date.
@@ -147,12 +110,6 @@
     1.  <a id="fees">League Fees</a>
         1.  Payment
             1.  A one time payment of $200 will be collected by the commissioner from each team manager.
-        1.  Deadline
-            1.  Initial payment must be paid on or before the draft date in 2021 and on or before August 1 in subsequent seasons.
-                1.  Any manager who does not pay by this time may have their team transferred, sold, or auctioned to another manager and the Comissioner's discression.
-                1.  Any proceeds from the transfer will be given to the previous manager.
-            1.  Managers will have a chance to review the rules before committing to the league.
-                1.  If 12 managers do not commit, the initial payment will be refunded.
     1.  <a id="payouts">Payouts</a>
         1.  Playoffs ($2,000 total)
             1.  1st place - $1,100
@@ -162,7 +119,7 @@
         1.  Losers bracket ($100)
             1.  Winner of the losers bracket will win $100.
         1.  Points ($100)
-            1.  Most points in the regular season - $100
+            1.  Most points in the regular season wins $100.
         1.  Best worst player ($50)
             1.  Each team will have a chance to win best worst player every week.
             1.  In a single week, a team's "worst player" is the active player that scores the least points on a team that fills all roster positions for that week.
@@ -182,7 +139,7 @@
             1.  Ties will go to the team who scored the most points in the weeks that their earned their point for this prize, or a coin flip if still tied.
         1.  Weekly prizes ($400)
             1.  During weeks 10-13, each team in the top scoring matchup will win $50 each week.
-            1.  If there is a tie for highest scoring matchup, the prize will be split among all tied teams.
+            1.  If there is a tie for highest scoring matchup, the tie goes to the pair of teams in the same matchup with the most total points on season so far, then coin flip.
 1.  <a id="moves">Moves</a>
     1.  Moves are defined as player adds, trades, and drops.
     1.  Players may only be dropped by a manager if the manager intends to immediately replace the slot on his or her roster.
@@ -192,7 +149,7 @@
             1.  During the multipart execution of a threeway trade, managers may object to any component trade, independant of the other trades. Furthermore, managers are not beholden to any agreement to make a trade in the future based on the conditions of any previous trade. For these reasons, threeway trades can never be guarenteed.
         1.  Tradebacks and double trades are disallowed
             1.  Tradebacks are when a manager makes a trade to gain a player that he or she once traded away without the player falling to Waivers or Free Agency between trades.
-            1.  Double trades are when a manager trades a player that was acquired in a different trade less than 24 hours prior.
+            1.  Double trades are when a manager trades a player that was acquired in a different trade less than 36 hours prior.
             1.  Tradebacks and double trades will be reversed immediately without a vote provided that a single manager points out that a tradeback or double trade occured within 24 hours of such trade.
         1.  Expedited Trades
             1.  Trades are processed immediately by Yahoo, but our rules states that trades may be objected within 24 hours after the trade is made and a vote to overturn a trade may take up to 36 hours after the trades is made.
@@ -234,7 +191,7 @@
             1. Commissioner gives no guarentee that he will act quickly in this situation as his number 1 priority will be to lift the suspension and/or resolve the league vote.
         1.  Conditional moves will be processed after the objection vote in the order which they were publicly communicated to the league chatroom. For this reason, managers are encouraged to post it themselves, rather than wait for the commissioner.
         1.  Managers should not consider specific conditional moves or roster modifications made after an objected move when voting on such objection.
-1.  <a id="voting">Voting</a>
+1.  <a id="voting">Voting and Objections</a>
     1.  The commissioner will be the sole interpreter of all rules.
     1.  For ambiguous situations not clearly covered by the rules, the commissioner will first check for precedent from past rulings or deleted rules that may still be part of common league understanding.
     1.  If no precedent exists, ambiguous situations will be resolved by majority league vote.
@@ -259,16 +216,18 @@
         1.  Managers disqualified from voting will implicitly abstain from the vote.
 1.  <a id="seeding">Seeding</a>
     1.  Regular Season
-        2. Seeding in the regular season will order teams from most to least games won with the added condition that every team who wins their division makes the playoffs (i.e., finishes with a top 6 seed).
+        1. Seeding in the regular season will order teams from most to least games won. The top 7 teams make the playoffs.
     1.  <a id="tie-breakers">Tie breakers</a>
         1.  Most ties in regular season
-        1.  Longest winning streak counting backwards from the end of the regular season.
-        1.  Shortest losing streak counting backwards from the end of the regular season.
-        1.  The previous two conditions will be applied iteratively backwards through the season until the tie is broken.
+        1.  <a id="winning-streaks">Longest win streak / shortest losing streak to end the season</a>
+            1.  Longest winning streak counting backwards from the end of the regular season (i.e., longest win streak to end the year).
+            1.  Shortest losing streak counting backwards from the end of the regular season.
+            1.  The previous two conditions will be applied iteratively backwards through the season until the tie is broken.
+                1.  For example: if two teams both end with 3-game win streaks, we compare their losing streaks before those wins, then their win streaks before those losses, and so on.
         1.  Most points in regular season
         1.  Coin flip 
     1.  <a id="ties">Ties in playoffs</a>
-        1.  In the event of a tied game during the postseason, the win will be awarded to the team with the lower seed.
+        1.  In the event of a tied game during the postseason, the win will be awarded to the team with the bottom seed.
 1.  <a id="abandoned-teams">Amandoned Teams</a>
     1.  Managers should keep an eye on their teams at least once a week, set their lineups in a way that they expect to win their games, and add and drop players to prepare to win more games.
         1.  Managers should stay competitive even if they don't think they can improve their chances of making the playoffs or win prizes.
@@ -294,7 +253,8 @@
     1.  Elective autopilot
         1.  Subject to commissioner approval, any manager may have their team temporarily put on autopilot if they are preoccupied with a life emergency by letting the comissioner know of their preoccupation.
 1.  <a id="outside-influence">Outside influence</a>
-    1.  No external value to the league, including monetary value, may be exchanged between managers for moves or any other manager decision.
+    1.  No external value to the league, including monetary value or a "gentleman's agreement," may be exchanged between managers for moves or any other manager decision.
+        1.  For example, managers may not agree to make a trade today in exchange for an obligation to make some other trade at another time.
     1.  No side bets or games of chance shall be wagered by a manager, aside from those outlined by these rules, that rewards that manager for making a decision that reduces his or her team's chance of winning a match up.
     1.  Breaking rules related to "Outside influence" may result in a majority league vote for disqualification from playoffs, withholding of prizes and/or expulsion from the league.
 1.  <a id="rules-not-stated">Rules Not Stated</a>

--- a/rules.md
+++ b/rules.md
@@ -7,7 +7,7 @@
         1.  [Playoffs](#playoffs)
     1.  [Money](#money)
         1.  [League Fees](#fees)
-        1.  [Payouts ($2,800 total)](#payouts)
+        1.  [Payouts ($2,400 total)](#payouts)
     1.  [Moves](#moves)
         1.  [Trades](#trades)
     1.  [Objections](#objections)
@@ -26,22 +26,22 @@
         1.  This section provides a brief summary for those who don't need all the details.
         1.  If a conflict exists between this section and another section below, this section will be invalid.
     1.  [League Settings](https://football.fantasysports.yahoo.com/f1/456171/settings)
-        1.  14 teams
+        1.  12 teams. 3 divisions of 4 teams each.
         1.  No keepers / fresh start every year
         1.  Live snake [draft](#draft) on Monday, September 1 at 8:45pm ET.
-        1.  Roster: 1 QB, 2 WR, 2 RB, 1 TE, 1 FLEX, 1 K, 1 DST, 4 bench, 2 IR.
-        1.  [Regular season](#regular-season): 13 weeks, each team plays every other team once.
-        1.  [Playoffs](#playoffs): 7 teams over 3 weeks (14-16), with 1 bye.
-        1.  Trade deadline is Saturday of week 10.
+        1.  Roster: 1 QB, 2 WR, 2 RB, 1 TE, 1 FLEX, 1 K, 1 DST, 5 bench, 1 IR.
+        1.  [Regular season](#regular-season): 14 weeks, each team plays division teams twice and other teams once.
+        1.  [Playoffs](#playoffs): 6 teams over 3 weeks (15-17), with 2 byes.
+        1.  Trade deadline is Saturday of week 11.
         1.  FAB waivers with least recently used tie-breaking.
         1.  Decimal and negative scoring enabled.
         1.  All other league and scoring settings can be found on the [Yahoo Fantasy settings page](https://football.fantasysports.yahoo.com/f1/456171/settings).
     1.  Money Rules
         1.  [League fee](#fees) is $200.
-        1.  Top 4 [playoff finishers](#playoff-payouts) win money: 1st ($1,100), 2nd ($450), 3rd ($350), and 4th ($100).
+        1.  Top 4 [playoff finishers](#playoff-payouts) win money: 1st ($1,000), 2nd ($400), 3rd ($300), and 4th ($100).
         1.  The team who scores the [most points](#points-prize) wins $100.
         1.  4 other [regular season prizes](#regular-season-prizes) of $50 each.
-        1.  [Weekly prizes](#weekly-prizes): $50 for each team in the top scoring matchup during weeks 10-13.
+        1.  [Weekly prizes](#weekly-prizes): $50 for each team in the top scoring matchup during weeks 12-14.
         1.  The winner of the [losers bracket](#losers-bracket-prize) wins $100.
         1.  Teams should not create [conflicts of interest](#outside-influence) with the league (e.g., betting that your team will lose or your players will do poorly).
     1.  Additional Rules
@@ -62,44 +62,43 @@
     1.  <a id="regular-season">Regular Season</a>
         1.  The schedule will be randomly determined before draft picks are selected at the start of the season.
         1.  The following criteria will be enforced when randomizing the schedule:
-            1.  There will be 13 games for each team in the regular season, corresponding to the first 13 weeks of the NFL regular season.
-            1.  Each team will play against every other team exactly once.
+            1.  There will be 14 games for each team in the regular season, corresponding to the first 14 weeks of the NFL regular season.
+            1.  Each team will play against each other team in their division twice and each team in the other divisions once.
+                1.  Division teams will be played once in the first 3 weeks and once again in the last 3 weeks.
     1.  <a id="playoffs">Playoffs</a>
-        1.  7 Teams will qualify for the playoffs.
+        1.  6 Teams will qualify for the playoffs.
             1.  Yahoo sometimes doesn't support our playoff seeding rules, so the real playoff schedule will be announced by the commissioner each week.
-        1.  The 1 seed will receive a bye on week 14.
-        1.  <a id="choosing-opponents">Playoffs will take place during weeks 14 through 16.</a>
-            1.  Week 14 matchups
-                1.  Seed 2 chooses a team among seeds 3 through 7, that they will play against.
-                    1. This choice must be made on or before 1:00 PM (ET) on the Tuesday before the games, or the choice will default to the bottom seed.
-                1.  The top remaining seed (seed 3 or 4, whichever was not chosen by seed 2) chooses their opponent from the remaining teams.
-                    1. This choice must be made on or before 4:00 PM (ET) on the Tuesday before the games, or the choice will default to the bottom seed.
-                1.  The final two remaining teams play each other.
+        1.  The top two seeds in the regular season will receive a bye on week 15.
+        1.  <a id="choosing-opponents">Playoffs will take place during weeks 15 through 17.</a>
             1.  Week 15 matchups
-                1.  Seed 1 chooses a team among the three winners of week 14 to play against.
+                1.  Seed 3 chooses a team among seeds 4 through 6, that they will play against.
                     1. This choice must be made on or before 1:00 PM (ET) on the Tuesday before the games, or the choice will default to the bottom seed.
-                1.  The remaining two winners of week 14 play against each other.
+                1.  The remaining two teams between seeds 4 and 6 play against each other.
             1.  Week 16 matchups
+                1.  Seed 1 chooses a team among the winners of week 15 to play against.
+                    1. This choice must be made on or before 1:00 PM (ET) on the Tuesday before the games, or the choice will default to the bottom seed.
+                1.  The remaining two winners of week 15 play against each other.
+            1.  Week 17 matchups
                 1.  Super Bowl
-                    1.  Two teams that won week 15 face off.
+                    1.  Two teams that won week 16 face off.
                     1.  Winner is 1st place
                     1.  Loser is 2nd place
                 1.  3rd place game
-                    1.  Two teams that lost week 15 face off.
+                    1.  Two teams that lost week 16 face off.
                     1.  Winner is 3rd place
                     1.  Loser is 4th place
         1.  Losers Bracket
-            1.  A 7 team losers bracket will be set up for teams that do not make the playoffs (seeds 8-14).
+            1.  A 6 team losers bracket will be set up for teams that do not make the playoffs (seeds 7-12).
             1.  Losers bracket seeding will use the same tie-breaking method as regular season seeding, except total wins and ties will be ignored and the primary seeding method will be [winning/losing streaks](#winning-streaks).
             1.  Losers bracket opponent selection follows the same rules as the main playoffs:
-                1.  Week 14: Seed 9 chooses first (by 1:00 PM ET Tuesday), then the top remaining seed among 10-14 chooses (by 4:00 PM ET Tuesday).
-                1.  Week 15: Seed 8 chooses among the winners (by 1:00 PM ET Tuesday).
+                1.  Week 15: Seed 9 chooses a team among seeds 10-12 (by 1:00 PM ET Tuesday).
+                1.  Week 16: Seed 7 chooses among the winners (by 1:00 PM ET Tuesday).
         1.  Playoff choice delays
             1.  If the NFL or Yahoo causes a matchup to be incomplete by the time playoff opponent choices are due, or Yahoo delays waivers, then the choice deadline will be delayed until the first day after the matchups are complete or until the last day before the new waiver date.
         1.  <a id="fab-bonuses">FAB bonuses</a>
-            1.  Each team that makes the playoffs will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 14.
-            1.  Teams in the Super Bowl will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 16.
-            1.  Teams in the 3rd place game will receive half the amount of FAB they started the season with credited on top of their existing balance at the start of week 16.
+            1.  Each team that makes the playoffs will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 15.
+            1.  Teams in the Super Bowl will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 17.
+            1.  Teams in the 3rd place game will receive half the amount of FAB they started the season with credited on top of their existing balance at the start of week 17.
         1.  <a id="team-locking">Team locking</a>
             1.  Teams will be locked once they are no longer in contention for 1st place, 3rd place, or winner of the losers bracket.
 1.  <a id="money">Money</a>
@@ -107,10 +106,10 @@
         1.  Payment
             1.  A one time payment of $200 will be collected by the commissioner from each team manager.
     1.  <a id="payouts">Payouts</a>
-        1.  <a id="playoff-payouts">Playoffs ($2,000 total)</a>
-            1.  1st place - $1,100
-            1.  2nd place - $450
-            1.  3rd place - $350
+        1.  <a id="playoff-payouts">Playoffs ($1,800 total)</a>
+            1.  1st place - $1,000
+            1.  2nd place - $400
+            1.  3rd place - $300
             1.  4th place - $100
         1.  <a id="losers-bracket-prize">Losers bracket ($100)</a>
             1.  Winner of the losers bracket will win $100.
@@ -134,8 +133,8 @@
                 1.  Each week, the team with the highest score will be awarded 1 point toward this prize.
                 1.  At the end of the regular season, the team with the most points will win.
                 1.  Ties will go to the team who scored the most points in the weeks that their earned their point for this prize, or a coin flip if still tied.
-        1.  <a id="weekly-prizes">Weekly prizes ($400)</a>
-            1.  During weeks 10-13, each team in the top scoring matchup will win $50 each week.
+        1.  <a id="weekly-prizes">Weekly prizes ($300)</a>
+            1.  During weeks 12-14, each team in the top scoring matchup will win $50 each week.
             1.  If there is a tie for highest scoring matchup, the tie goes to the pair of teams in the same matchup with the most total points in the season so far, then coin flip.
 1.  <a id="moves">Moves</a>
     1.  Moves are defined as player adds, trades, and drops.
@@ -213,7 +212,7 @@
         1.  Managers disqualified from voting will implicitly abstain from the vote.
 1.  <a id="seeding">Seeding</a>
     1.  Regular Season
-        1. Seeding in the regular season will order teams from most to least games won. The top 7 teams make the playoffs.
+        1. Seeding in the regular season will order teams from most to least games won with the added condition that every team who wins their division makes the playoffs (i.e., finishes with a top 6 seed).
     1.  <a id="tie-breakers">Tie breakers</a>
         1.  Most ties in regular season
         1.  <a id="winning-streaks">Longest win streak / shortest losing streak to end the season</a>

--- a/rules.md
+++ b/rules.md
@@ -2,7 +2,6 @@
     1.  [TLDR](#tldr)
     1.  [Managers](#managers)
     1.  [Draft](#draft)
-        1.  [Keepers](#keepers)
     1.  [Schedule](#schedule)
         1.  [Regular Season](#regular-season)
         1.  [Playoffs](#playoffs)
@@ -32,24 +31,23 @@
         1.  This section is intended to be a brief summary of the rules.
         1.  If a conflict exists between this section and another section below, this section will be invalid.
     1.  Summary
-        1.  There are 12 teams.
+        1.  There are 14 teams.
         1.  Each team has 14 players + 1 IR.
         1.  A team can play 1 QB, 2 WR, 2 RB, 1 TE, 1 FLEX, 1 K, and 1 DST each week.
-        1.  The regular season is 14 weeks, with each team playing each other team exactly once.
-        1.  The playoffs will have 6 teams, two will get a bye, and take place on weeks 15 through 17.
+        1.  The regular season is 13 weeks, with each team playing every other team exactly once.
+        1.  The playoffs will have 8 teams, four will get a bye, and take place on weeks 14 through 17.
         1.  The draft time is on the Sunday before the first game each season at 8pm.
-        1.  Starting in 2022, we will do keepers. You may keep a few players for 1 year and 1 player for 2 years. Other restrictions apply -- see details in [keepers](#keepers) rules.
         1.  We'll use FAAB to determine waiver claims and break ties with least recently used.
-        1.  There will be 3 divisions of 4 teams.
         1.  League fee is $200.
         1.  Trades are allowed and the trade deadline will be the Saturday of week 12.
         1.  Trades will process immediately by Yahoo, but any manager may object and a majority vote will determine whether the trade is overturned.
         1.  In this league, it is against the rules to stop trying. If you make an "[undoubtably bad move](#undoubtably)", your line up will be set for you and your team may be put on autopilot.
         1.  Rules changes in season require a unanimous vote. For future seasons, they require a majority vote and Comissioner approval.
-        1.  People who make the playoffs win at least $50 with 1st through 4th winning $1,000, $500, $250, and $100.
-        1.  The team to score 1st place in the regular season will win $100.
-        1.  The team who scores the most points wins $150.
-        1.  There are 4 other prizes of $50 each.
+        1.  Only the top 4 playoff finishers win money: 1st ($1,000), 2nd ($400), 3rd ($350), and 4th ($100).
+        1.  The team who scores the most points wins $200.
+        1.  There are 4 other prizes of $50 each, plus $50 for most FAAB remaining among playoff teams.
+        1.  Weekly prizes: $50 for each team in the top scoring matchup during weeks 10, 11, 12, and 13.
+        1.  The winner of the losers bracket wins $100.
         1.  People shouldn't create conflicts of interest with the league.
         1.  If a rule isn't defined well here, we fall back to Yahoo rules. If it's still not clear, we use a league vote.
         1.  All times in these rules are Eastern Standard Time.
@@ -102,58 +100,39 @@
             1. Setting preferences and defaults
                 1. Any manager may post a list of draft position preferences publicly to the league at anytime and the most preferred draft position in their preference list will be automatically selected for them.
                 1. If a manager does not choose their draft position by their draft position by their assiigned deadline, the lowest remaining draft position will be assigned.
-    1.  <a id="keepers">Keepers</a>
-        1.  Starting in the 2022 season, managers may elect to keep players from previous seasons within the limitations laid out in this section.
-        1.  Keeper elections must be made by end of day, 5 days before the draft.
-        1.  Cost of keeping a player
-            1.  The first year a player is kept, they will cost one draft round less than the round they were drafted the previous year.
-                1.  For example a player drafted in the 5th round, will cost a 4th round pick the following year.
-                1.  An undrafted player will cost a last round pick the following year.
-                1.  A first round pick cannot be kept the following year.
-            1.  The second year a player is kept, they will cost a first round pick unless they cost a first round pick the previous year, in which case they cannot be kept a second year.
-            1.  No player may be kept 3 consecutive drafts, nor may a player be kept in one draft if they cost a 1st round pick ni the previious draft.
-            1.  Players acquired through FA, WW, or trades will retain their draft round (or lack of draft round) for the purposes of determining their cost the keep the following year.
-        1.  Teams may not keep any combination of players who's total draft round costs exceed 15.
-            1.  Examples
-                1. Keeping players who cost a 10th and 5th round pick totals 15. This is allowed.
-                1. Keeping players who cost a 12th, 3rd, and 1st round pick totals 16. This is not allowed.
-        1.  If you choose to keep multiple players who cost the same draft round, you may pay a lesser draft round.
-            1.  Such changes do not reduce the cost of keeping a player for the sake of determining whether the total costs exceed 15.
-            1.  Such changes do affect the round that a player costs to keep next year and could result in making the player unkeepable next year if a 1st round pick is sacrificed  year.
 1.  <a id="schedule">Schedule</a>
     1.  <a id="regular-season">Regular Season</a>
-        1.  The schedule will be randomly determined before keepers and draft picks are selected at the start of the season.
+        1.  The schedule will be randomly determined before draft picks are selected at the start of the season.
             1. Commissioner will use the best tools reasonably available to randomize the schedule and do his best to show that it was truly random.
         1.  The following criteria will be enforced when randomizing the schedule:
-            1.  There will be 14 games for each team in the regular season, corresponding to the first 14 weeks of the NFL regular season.
-            1.  Each team will play against each other team in their division twice and each team in the other divisions once.
+            1.  There will be 13 games for each team in the regular season, corresponding to the first 13 weeks of the NFL regular season.
+            1.  Each team will play against every other team exactly once.
     1.  <a id="playoffs">Playoffs</a>
-        1.  6 Teams will qualify for the playoffs.
+        1.  7 Teams will qualify for the playoffs.
             1.  Yahoo sometimes doesn't support our playoff seeding rules, so the real playoff schedule will be announced by the commissioner each week.
-        1.  The highest two seeds in the regular season will receive a bye on week 15.
-        1.  Playoffs will take place during weeks 15 through 17.
-            1.  Week 15 matchups
-                1.  Seed 3 chooses a team among seeds 4 though 6, that they will play against.
+        1.  The highest seed in the regular season will receive a bye on week 14.
+        1.  Playoffs will take place during weeks 14 through 16.
+            1.  Week 14 matchups
+                1.  Seed 2 chooses a team among seeds 3 through 7, that they will play against.
                     1. This choice must be made on or before 1pm (EST) the Tuesday before the games or the choice will default to the highest available seed number.
-                1.  The remaining two teams between seeds 4 and 6 play against each other.
-            1.  Week 16 matchups
-                1.  Seed 1 chooses a team among the winners of week 15 to play against.
+                1.  The best remaining seed (lowest number among 3-7, excluding seed 2's choice) chooses their opponent from the remaining teams.
+                1.  The final two remaining teams play each other.
+            1.  Week 15 matchups
+                1.  Seed 1 chooses a team among the three winners of week 14 to play against.
                     1. This choice must be made on or before 7pm (EST) the Tuesday before the games or the choice will default to the highest available seed number.
-                1.  Remaining two winners of week 15 faceoff.
-                1.  The remaining two losing teams from week 15 will play against each other.
-                    1.  The losing team gets 6th place.
-            1.  Week 17 matchups
+                1.  The remaining two winners of week 14 play against each other.
+            1.  Week 16 matchups
                 1.  Superbowl
-                    1.  Two teams that won weeks 15 and 16 faceoff.
+                    1.  Two teams that won week 15 faceoff.
                     1.  Winner is 1st place
                     1.  Loser is 2nd place
                 1.  3rd place game
-                    1.  Two teams that won week 15 and lost week 16 faceoff.
+                    1.  Two teams that lost week 15 faceoff.
                     1.  Winner is 3rd place
                     1.  Loser is 4th place
         1.  Losers Bracket
-            1.  A 6 team losers bracket will be set up in the same manner as the playoffs with the 7 seed acting in the same way as the 1 seed (with a week 15 bye), the 8 seed like 2, 9 like 3, etc. all the way up to the 12 seed who act in the same way as the 6th.
-            1.  No money prizes will be awarded in the losers bracket, but draft order will be determined as perscribed by the draft section of the rules.
+            1.  A 7 team losers bracket will be set up for teams that do not make the playoffs (seeds 8-14).
+            1.  Losers bracket seeding will be determined by the length of each team's winning streak counting backwards from the end of the regular season, with the longest streak receiving the best seed.
 1.  <a id="money">Money</a>
     1.  <a id="fees">League Fees</a>
         1.  Payment
@@ -165,15 +144,13 @@
             1.  Managers will have a chance to review the rules before committing to the league.
                 1.  If 12 managers do not commit, the initial payment will be refunded.
     1.  <a id="payouts">Payouts</a>
-        1.  Playoffs ($1,950 total)
+        1.  Playoffs ($1,850 total)
             1.  1st place - $1,000
-            1.  2nd place - $500
-            1.  3rd place - $250
+            1.  2nd place - $400
+            1.  3rd place - $350
             1.  4th place - $100
-            1.  5th place - $50
-            1.  6th place - $50
-        1.  Points ($150)
-            1.  Most points in the regular season - $150
+        1.  Points ($200)
+            1.  Most points in the regular season - $200
         1.  Best worst player ($50)
             1.  Each team will have a chance to win best worst player every week.
             1.  In a single week, a team's "worst player" is the active player that scores the least points on a team that fills all roster positions for that week.
@@ -191,8 +168,14 @@
             1.  Each week, the team with the highest score will be awarded 1 point toward this prize.
             1.  At the end of the regular season, the team with the most points will win.
             1.  Ties will go to the team who scored the most points in the weeks that their earned their point for this prize, or a coin flip if still tied.
-        1. Regular Season ($100)
-            1. First place in the regular season will win $100
+        1.  Weekly prizes ($400)
+            1.  Each team in the top scoring matchup during weeks 10, 11, 12, and 13 will win $50 each.
+            1.  If there is a tie for highest scoring matchup, the prize will be split among all tied teams.
+        1.  Most FAAB ($50)
+            1.  The team that makes the playoffs with the most FAAB remaining will win $50.
+            1.  Ties will be broken by highest waiver priority (same as FAAB tie-breaking for player pickups).
+        1.  Losers bracket ($100)
+            1.  Winner of the losers bracket will win $100.
         1.  All prizes will be paid out no later than the real NFL Super Bowl.
         1.  After week 15, any players remaining in the playoffs may renegotiate the prizes for 1st through 4th place provided that the new prize distribution is proposed to the commissioner by the highest seeded remaining manager and all other remaining managers accept.
 1.  <a id="moves">Moves</a>

--- a/rules.md
+++ b/rules.md
@@ -245,7 +245,7 @@
             1.  Once enough players are dropped to meet the roster size requirement, stop.
             1.  Exclude dropping any players on Yahoo's can't cut list.
             1.  Exclude dropping any players of any position that would prepare to leave the team in a future state of not being able to fill the team with players projected more than 0 points unless this excludes all players.
-            1.  Drop the remaining player with the smallest maximum projected weekly score left of the weeks leading to week 14 in the regular season and 17 in the playoffs.
+            1.  Drop the remaining player with the smallest maximum projected weekly score left of the remaining weeks through the end of the regular season (if the move is during regular season) or through Super Bowl week (if the move is during playoffs).
     1.  The commissioner may at any time call a majority league vote to take a team off autopilot.
     1.  Elective autopilot
         1.  Subject to commissioner approval, any manager may have their team temporarily put on autopilot if they are preoccupied with a life emergency by letting the commissioner know of their preoccupation.

--- a/rules.md
+++ b/rules.md
@@ -25,37 +25,36 @@
     1.  Disclaimer
         1.  This section provides a brief summary for those who don't need all the details.
         1.  If a conflict exists between this section and another section below, this section will be invalid.
-    1.  League Settings
+    1.  [League Settings](https://football.fantasysports.yahoo.com/f1/456171/settings)
         1.  14 teams
         1.  No keepers / fresh start every year
-        1.  Live snake draft on Monday, September 1 at 8:45pm ET.
+        1.  Live snake [draft](#draft) on Monday, September 1 at 8:45pm ET.
         1.  Roster: 1 QB, 2 WR, 2 RB, 1 TE, 1 FLEX, 1 K, 1 DST, 4 bench, 2 IR.
-        1.  Regular season: 13 weeks, each team plays every other team once.
-        1.  Playoffs: 7 teams over 3 weeks (14-16), with 1 bye.
-        1.  Trade deadline is week 10.
+        1.  [Regular season](#regular-season): 13 weeks, each team plays every other team once.
+        1.  [Playoffs](#playoffs): 7 teams over 3 weeks (14-16), with 1 bye.
+        1.  Trade deadline is Saturday of week 10.
         1.  FAB waivers with least recently used tie-breaking.
         1.  Decimal and negative scoring enabled.
         1.  All other league and scoring settings can be found on the [Yahoo Fantasy settings page](https://football.fantasysports.yahoo.com/f1/456171/settings).
     1.  Money Rules
-        1.  League fee is $200.
-        1.  Playoff finishers win money: 1st ($1,100), 2nd ($450), 3rd ($350), and 4th ($100).
-        1.  The team who scores the most points wins $100.
-        1.  4 other regular season prizes of $50 each.
-        1.  Weekly prizes: $50 for each team in the top scoring matchup during weeks 10-13.
-        1.  The winner of the losers bracket wins $100.
-        1.  Teams should not create conflicts of interest with the league (e.g., betting that your team will lose or your players will do poorly).
+        1.  [League fee](#fees) is $200.
+        1.  Top 4 [playoff finishers](#playoff-payouts) win money: 1st ($1,100), 2nd ($450), 3rd ($350), and 4th ($100).
+        1.  The team who scores the [most points](#points-prize) wins $100.
+        1.  4 other [regular season prizes](#regular-season-prizes) of $50 each.
+        1.  [Weekly prizes](#weekly-prizes): $50 for each team in the top scoring matchup during weeks 10-13.
+        1.  The winner of the [losers bracket](#losers-bracket-prize) wins $100.
+        1.  Teams should not create [conflicts of interest](#outside-influence) with the league (e.g., betting that your team will lose or your players will do poorly).
     1.  Additional Rules
         1.  It's against the rules to stop trying. If you make one or more "[undoubtedly bad moves](#undoubtedly)," the moves may be reversed, your lineup may be set for you, and your team may be put on autopilot.
             1.  Do not stop trying! The weekly prizes, regular season prizes, and $100 for losers bracket mean you can still win your money back.
-        1.  Trades are allowed and the trade deadline is week 10.
-        1.  Trades will process immediately by Yahoo, but any manager may object within 24 hours and the trade will be reversed if a majority votes against it.
+        1.  [Trades](#expedited-trades) will process immediately by Yahoo, but any manager may object within 24 hours and the trade will be reversed if a majority votes against it.
         1.  We use [longest win-streak](#winning-streaks) to end the year as a tie-breaking method for the playoffs and as the primary seeding method for the losers bracket to make sure the final weeks are always competitive.
         1.  Top seeded playoff teams [choose their opponents](#choosing-opponents) each week.
-        1.  Playoff teams receive [FAB bonuses](#playoffs) during the playoffs so that they maintain waiver priority over losers bracket.
-        1.  Teams get locked in the post-season when out of contention for top 4 or losers bracket winner.
-        1.  If a rule isn't defined here, we fall back on Yahoo's rules.
-        1.  If a rule is still ambiguous, we have a league vote.
-        1.  All times are Eastern Time (ET).
+        1.  Playoff teams receive [FAB bonuses](#fab-bonuses) during the playoffs so that they maintain waiver priority over losers bracket.
+        1.  [Teams get locked in the post-season](#team-locking) when out of contention for top 4 or losers bracket winner.
+        1.  If a [rule isn't defined](#rules-not-stated) here, we fall back on Yahoo's rules.
+        1.  If a [rule is still ambiguous](#ambiguous-votes), we have a league vote.
+        1.  [All times are Eastern Time (ET).](#time)
 1.  <a id="draft">Draft</a>
     1.  Live snake draft on Monday, September 1 at 8:45pm ET.
     1.  Draft order will be determined after all teams commit to the league by paying their league dues and at least 1 hour before the draft.
@@ -97,44 +96,45 @@
                 1.  Week 15: Seed 8 chooses among the winners (by 1:00 PM ET Tuesday).
         1.  Playoff choice delays
             1.  If the NFL or Yahoo causes a matchup to be incomplete by the time playoff opponent choices are due, or Yahoo delays waivers, then the choice deadline will be delayed until the first day after the matchups are complete or until the last day before the new waiver date.
-        1.  FAB bonuses
+        1.  <a id="fab-bonuses">FAB bonuses</a>
             1.  Each team that makes the playoffs will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 14.
             1.  Teams in the Super Bowl will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 16.
             1.  Teams in the 3rd place game will receive half the amount of FAB they started the season with credited on top of their existing balance at the start of week 16.
-        1.  Team locking
+        1.  <a id="team-locking">Team locking</a>
             1.  Teams will be locked once they are no longer in contention for 1st place, 3rd place, or winner of the losers bracket.
 1.  <a id="money">Money</a>
     1.  <a id="fees">League Fees</a>
         1.  Payment
             1.  A one time payment of $200 will be collected by the commissioner from each team manager.
     1.  <a id="payouts">Payouts</a>
-        1.  Playoffs ($2,000 total)
+        1.  <a id="playoff-payouts">Playoffs ($2,000 total)</a>
             1.  1st place - $1,100
             1.  2nd place - $450
             1.  3rd place - $350
             1.  4th place - $100
-        1.  Losers bracket ($100)
+        1.  <a id="losers-bracket-prize">Losers bracket ($100)</a>
             1.  Winner of the losers bracket will win $100.
-        1.  Points ($100)
+        1.  <a id="points-prize">Points ($100)</a>
             1.  Most points in the regular season wins $100.
-        1.  Best worst player ($50)
-            1.  Each team will have a chance to win best worst player every week.
-            1.  In a single week, a team's "worst player" is the active player that scores the least points on a team that fills all roster positions for that week.
-            1.  The best worst player award will go to the manager of the team who had the highest scoring worst player in any single week of the year.
-            1.  Ties will go to the team with the better 2nd worst player on the given week, then 3rd, 4th, and so on.
-        1.  Best worst week ($50)
-            1.  At the end of the year, each team's "worst week" will be defined as the week that they scored their minimum score.
-            1.  A manager will win best worst week if their team's worst week had a higher score than any other team.
-            1.  Ties will go to the team with the better 2nd worst week, then 3rd, 4th, and so on.
-        1.  Best week ($50)
-            1.  Each team will have a chance to win best week every week.
-            1.  The team with the highest scoring single week will win.
-            1.  Ties will go to the team with the 2nd highest scoring week, then 3rd, 4th, and so on.
-        1.  Most best weeks ($50)
-            1.  Each week, the team with the highest score will be awarded 1 point toward this prize.
-            1.  At the end of the regular season, the team with the most points will win.
-            1.  Ties will go to the team who scored the most points in the weeks that their earned their point for this prize, or a coin flip if still tied.
-        1.  Weekly prizes ($400)
+        1.  <a id="regular-season-prizes">Regular Season Prizes ($200 total)</a>
+            1.  Best worst player ($50)
+                1.  Each team will have a chance to win best worst player every week.
+                1.  In a single week, a team's "worst player" is the active player that scores the least points on a team that fills all roster positions for that week.
+                1.  The best worst player award will go to the manager of the team who had the highest scoring worst player in any single week of the year.
+                1.  Ties will go to the team with the better 2nd worst player on the given week, then 3rd, 4th, and so on.
+            1.  Best worst week ($50)
+                1.  At the end of the year, each team's "worst week" will be defined as the week that they scored their minimum score.
+                1.  A manager will win best worst week if their team's worst week had a higher score than any other team.
+                1.  Ties will go to the team with the better 2nd worst week, then 3rd, 4th, and so on.
+            1.  Best week ($50)
+                1.  Each team will have a chance to win best week every week.
+                1.  The team with the highest scoring single week will win.
+                1.  Ties will go to the team with the 2nd highest scoring week, then 3rd, 4th, and so on.
+            1.  Most best weeks ($50)
+                1.  Each week, the team with the highest score will be awarded 1 point toward this prize.
+                1.  At the end of the regular season, the team with the most points will win.
+                1.  Ties will go to the team who scored the most points in the weeks that their earned their point for this prize, or a coin flip if still tied.
+        1.  <a id="weekly-prizes">Weekly prizes ($400)</a>
             1.  During weeks 10-13, each team in the top scoring matchup will win $50 each week.
             1.  If there is a tie for highest scoring matchup, the tie goes to the pair of teams in the same matchup with the most total points in the season so far, then coin flip.
 1.  <a id="moves">Moves</a>
@@ -148,7 +148,7 @@
             1.  Tradebacks are when a manager makes a trade to gain a player that he or she once traded away without the player falling to Waivers or Free Agency between trades.
             1.  Double trades are when a manager trades a player that was acquired in a different trade less than 36 hours prior.
             1.  Tradebacks and double trades will be reversed immediately without a vote provided that a single manager points out that a tradeback or double trade occurred within 24 hours of such trade.
-        1.  Expedited Trades
+        1.  <a id="expedited-trades">Expedited Trades</a>
             1.  Trades are processed immediately by Yahoo, but our rules state that trades may be objected to within 24 hours after the trade is made and a vote to overturn a trade may take up to 36 hours after the trade is made.
             1.  Managers who make a trade to acquire a player less than 36 hours before they are expected to play may make [conditional moves or roster modifications](#conditional-moves) to be prepared for the case that their trade is objected and overturned.
 1.  <a id="objections">Objections</a>
@@ -191,7 +191,7 @@
 1.  <a id="voting">Voting and Objections</a>
     1.  The commissioner will be the sole interpreter of all rules.
     1.  For ambiguous situations not clearly covered by the rules, the commissioner will first check for precedent from past rulings or deleted rules that may still be part of common league understanding.
-    1.  If no precedent exists, ambiguous situations will be resolved by majority league vote.
+    1.  <a id="ambiguous-votes">If no precedent exists, ambiguous situations will be resolved by majority league vote.</a>
     1.  League votes should be completed within 24 hours with each team manager voting yes (to make some change) or no (to keep things as they are).
     1.  Managers may abstain from a vote.
         1. Managers who abstain will have their vote counted as a "no" for any votes lasting less than 24 hours.

--- a/rules.md
+++ b/rules.md
@@ -14,7 +14,6 @@
         1.  [Undoubtably bad moves](#undoubtably) (the most controversial rule we have)
         1.  [Suspending Moves](#suspending-moves)
     1.  [Voting](#voting)
-    1.  [Amending Rules](#amending-rules)
     1.  [Seeding](#seeding)
         1.  [Tie Breakers](#tie-breakers)
         1.  [Ties](#ties)
@@ -42,7 +41,6 @@
         1.  Trades are allowed and the trade deadline will be the Saturday of week 12.
         1.  Trades will process immediately by Yahoo, but any manager may object and a majority vote will determine whether the trade is overturned.
         1.  In this league, it is against the rules to stop trying. If you make an "[undoubtably bad move](#undoubtably)", your line up will be set for you and your team may be put on autopilot.
-        1.  Rules changes in season require a unanimous vote. For future seasons, they require a majority vote and Comissioner approval.
         1.  Only the top 4 playoff finishers win money: 1st ($1,000), 2nd ($400), 3rd ($350), and 4th ($100).
         1.  The team who scores the most points wins $200.
         1.  There are 4 other prizes of $50 each, plus $50 for most FAAB remaining among playoff teams.
@@ -194,14 +192,13 @@
             1.  Managers who make a trade to acquire a player less than 36 hours before they are expected to play may make [conditional moves or roster modifications](#conditional-moves) to be prepared for the case that their trade is objected and overturned.
 1.  <a id="objections">Objections</a>
     1.  Any move may be objected by any manager within 24 hours after the move is made.
-        1.  For trades this period starts when the trade is initiated; not processed.
+        1.  For trades this period starts when the trade is processed by Yahoo.
     1.  <a id="undoubtably">Undoubtably bad moves</a>
-        1.  A manager must not take any actions, including making [moves](#moves) and setting active players, such that at the time the action is initiated it undoubtably diminishes the value of his or her team by reducing such team's chances of making the playoffs, finishing the regular season with the best possible seed, leaving the team in a good state for subsequent seasons, and secondarily to the previously mentioned conditions reduces the chances of winning the current matchup.
+        1.  A manager must not take any actions, including making [moves](#moves) and setting active players, such that at the time the action is initiated it undoubtably diminishes the value of his or her team by reducing such team's chances of making the playoffs, finishing the regular season with the best possible seed, or winning the current matchup.
             1.  Such actions may include, but are not limited to:
                 1.  Leaving roster positions empty when a healthy alternative was available on the bench or free agency (FA).
                 1.  Putting a player on active roster that has been long known to be not participating in the given week.
                 1.  Dropping an exceptionally valuable player when a significantly lesser valued alternative player was available to be dropped.
-                1.  Letting go of obviosuly high valued keeper players in exchange for no meaninigful gain.
             1.  Exceptions may include:
                 1.  Pulling (or not pulling) a player from active roster after the manager's team has gained a lead that would be at risk if the player scored negative points.
                 1.  In rare cases, leaving a roster position empty because no alternative exists on the bench and no benched player is worth dropping.
@@ -218,7 +215,7 @@
         1.  An objection is not considered initiated until another manager seconds the intention to object.
         1.  Both the original intention to object and the seconding of the intention to object shall count as vote in favor of the objection.
         1.  Whenever an objection is initiated, the commissioner will clearly explain the situation publically to the league and outline the procedure for resolving it.
-        1.  When an objection is initiated, each manager in the league will have until 24 hours after the time the objection is initiated to perform a majority league vote to determine the outcome of the objection.
+        1.  When an objection is initiated, each manager in the league will have until 24 hours after the time the objection is initiated to perform a majority league vote to determine the outcome of the objection, but the entire process must complete within 36 hours of the original trade.
     1.  If an objection vote passes, the commissioner will do his best to reverse the actions that have been done as a result of the objection.
         1.  In some cases, this may include reversing other actions by other teams, if they are determined by a majority league vote to have been responses to the original objected action.
         1.  In the case that multiple actions need to be reversed, they will be determined in forward chronological order.
@@ -232,46 +229,28 @@
         1.  Managers should not consider specific conditional moves or roster modifications made after an objected move when voting on such objection.
     1.  Any use of the word "veto" or derivations thereof in this document or in the Yahoo interface including the message board shall be interpreted as having the same meaning as an objection unless otherwise stated.
 1.  <a id="voting">Voting</a>
-    1.  For any reasonable dispute that requires a league vote, the commissioner will gather and post all relevant information and make an initial ruling which shall be binding unless any manager objects in a reasonable time.
-    1. A league vote will only occur following an objection or other dispute if seconded by another manager.
-        1. In the case that a manager seconds an objection, that manager must vote in favor of the objection.
-        1. The league vote shall be considered initated at the time the objection was seconded.
-    1.  If any manager objects to the commissioner's initial ruling, a league vote shall be initiated.
+    1.  The commissioner will be the sole interpreter of all rules.
+    1.  For ambiguous situations not clearly covered by the rules, the commissioner will first check for precedent from past rulings or deleted rules that may still be part of common league understanding.
+    1.  If no precedent exists, ambiguous situations will be resolved by majority league vote.
     1.  League votes should be completed within 24 hours with each team manager voting yes (to make some change) or no (to keep things as they are).
     1.  Managers may abstain from a vote.
-        1. Managers who abstain will have their vote counted as a "no" for any votes lasting less than 8 hours.
-            1. For example, a rushed trade objection.
-        1. After 8 hours, managers who haven't voted will neither count for, nor against the proposal.
+        1. Managers who abstain will have their vote counted as a "no" for any votes lasting less than 24 hours.
+            1. For example, a rushed trade objection due to the 36-hour overall limit.
+        1. At 24 hours, managers who haven't voted will neither count for, nor against the proposal.
     1.  Majority votes shall pass if at least half of the teams who didn't abstain, vote yes.
         1. A majority vote shall pass immediately when this condition is met.
-    1.  Unanimous votes shall pass if a majority of managers vote yes and all other managers abstain.
     1.  An objection shall constitute a yes vote to reverse the objected action.
     1.  All votes must be cast publicly, in the message board, unconditionally, unambiguously, and by the manager who's opinion they represent.
         1.  Managers may change their vote at any time by casting a new vote that fits this criteria. The new vote will replace the old vote.
     1.  A majority vote will be required for:
-        1.  Objections.
+        1.  Objections to trades, undoubtedly bad moves or roster decisions, waiver abuse, and any other moves that may be appropriately objected.
         1.  Disambiguating any rules.
-            1.  The commissioner will determine upon request whether the rule is ambiguous or not. Non-ambiguous rules will only be changed via the rule amendment process.
-        1.  Replacing the commissioner.
-        1.  Anything else that doesn't explicitly require a unanimous vote.
     1.  Managers are disqualified from voting on a particular issue if they are directly involved with what is being voted upon.
         1.  Commissioner may make initial ruling, but will not participate in the league vote if he is directly involved.
         1.  Managers directly involved include but are not limited to
             1.  Managers gaining or losing players in a trade.
             1.  Managers matched up against a team that's being accused of making poor roster decisions.
         1.  Managers disqualified from voting will implicitly abstain from the vote.
-1.  <a id="amending-rules">Amending Rules</a>
-    1.  A unanimous vote will be required for any changes to the rules that go into effect during the season the amendment passes.
-    1.  Rules may be changed for subsequent seasons by a majority vote and comissioner approval.
-    1.  To amend the rules, a manager must make a clear proposal about which rules to be added, removed, or modified.
-        1.  For a period of time (defined in this section), other managers will have the chance to submit counter proposals.
-            1. From August 1 and Thursday before Superbowl; 1 week
-            1. From the Friday before the Superbowl to July 31; 4 weeks, but no more than 1 week past August 1
-        1.  Each manager may only submit one proposal or counter proposal to be considered per amendment vote.
-            1.  Managers may get around this by finding a co-sponsor who has not sponsored the original proposal or another counter proposal.
-        1.  The counter proposal to leave the rules unchanged will automatically be submitted for each vote without a sponsor required.
-        1.  After the proposal and counter proposals are all submitted, each manager may vote yes or no to each proposal.
-            1.  The proposal with the most yes votes will pass and effectively amend the rules, upon Comissioner approval.
 1.  <a id="seeding">Seeding</a>
     1.  Regular Season
         2. Seeding in the regular season will order teams from most to least games won with the added condition that every team who wins their division makes the playoffs (i.e., finishes with a top 6 seed).
@@ -290,14 +269,14 @@
     1.  Teams who fail to stay competitive may be declared abandoned and put through the abandoned team protocol if the following conditions are met.
         1.  A manager in the league accuses a manager of neglecting their team.
             1.  The accusing manager should describe the nature of the neglect.
-        1.  Such team has at the time of accusation taken action or inaction that has been reversed due to a successful objection.
+        1.  Such team has at the time of accusation taken action or inaction including roster decisions that has been reversed due to a successful objection.
     1.  A supermajority league vote will take place when a team is placed on abandonment protocol.
         1.  If this vote passes, the accused team will be placed on autopilot.
         1.  For this vote to pass, at least 70% of the managers who aren't already on autopilot, must vote yes.
     1.  <a id="autopilot">Autopilot</a>
         1.  When a team is placed on autopilot, the commissioner will set their line up each week in a predetermined fashion.
         1.  Any conditional moves or conditional roster modifications made by the manager will supersede the following rules provided that they are not successfully objected to.
-        1.  At time of the start of each game, the starting roster will be set to the players on the team or available on FA that have the greatest Yahoo projection.
+        1.  At time of the start of each game, the starting roster will be set to the players on the team or available on FA that have the greatest Yahoo projection. Ties in projections will be broken by coin flip.
         1.  Setting the roster may be done slightly after the game starts so that the projections lock in to their final value before the decision is made and so that any other team not on autopilot may have first dibs on any player.
         1.  If a player must be dropped to accommodate a FA add, the dropped player will be chosen using the following method:
             1.  If at any point, only one player is left, drop him.

--- a/rules.md
+++ b/rules.md
@@ -1,5 +1,5 @@
 1.  Table of contents
-    1.  [TLDR](#tldr)
+    1.  [Summary](#summary)
     1.  [Managers](#managers)
     1.  [Draft](#draft)
     1.  [Schedule](#schedule)
@@ -21,7 +21,7 @@
     1.  [Outside Influence](#outside-influence)
     1.  [Rules Not Stated](#rules-not-stated)
     1.  [Timezones](#timezones)
-1.  <a id="tldr">Summary</a>
+1.  <a id="summary">Summary</a>
     1.  Disclaimer
         1.  This section provides a brief summary for those who don't need all the details.
         1.  If a conflict exists between this section and another section below, this section will be invalid.

--- a/rules.md
+++ b/rules.md
@@ -130,7 +130,7 @@
                     1.  Loser is 4th place
         1.  Losers Bracket
             1.  A 7 team losers bracket will be set up for teams that do not make the playoffs (seeds 8-14).
-            1.  Losers bracket seeding will be determined by the length of each team's winning streak counting backwards from the end of the regular season, with the longest streak receiving the best seed.
+            1.  Losers bracket seeding will use the same tie-breaking method as regular season seeding, except total wins and ties will be ignored and the primary seeding method will be winning/losing streaks.
 1.  <a id="money">Money</a>
     1.  <a id="fees">League Fees</a>
         1.  Payment
@@ -255,9 +255,9 @@
         2. Seeding in the regular season will order teams from most to least games won with the added condition that every team who wins their division makes the playoffs (i.e., finishes with a top 6 seed).
     1.  <a id="tie-breakers">Tie breakers</a>
         1.  Most ties in regular season
-        1.  Longest winning streak at end of season.
-        1.  Shortest losing streak at end of season.
-        1.  The previous two conditions will be applied recursively until the tie is broken.
+        1.  Longest winning streak counting backwards from the end of the regular season.
+        1.  Shortest losing streak counting backwards from the end of the regular season.
+        1.  The previous two conditions will be applied iteratively backwards through the season until the tie is broken.
         1.  Most points in regular season
         1.  Coin flip 
     1.  <a id="ties">Ties in playoffs</a>

--- a/rules.md
+++ b/rules.md
@@ -50,7 +50,7 @@
         1.  Trades are allowed and the trade deadline is week 10.
         1.  Trades will process immediately by Yahoo, but any manager may object within 24 hours and the trade will be reversed if a majority votes against it.
         1.  We use longest [win-streak](#winning-streaks) to end the year as a tie-breaking method for the playoffs and as the primary seeding method for the losers bracket to make sure the final weeks are always competitive.
-        1.  Top seeded playoff teams choose their [opponents](#choosing-opponents) each week.
+        1.  Top seeded playoff teams [choose their opponents](#choosing-opponents) each week.
         1.  Playoff teams receive [FAB bonuses](#playoffs) during the playoffs.
         1.  Teams get locked in the post-season when out of contention for top 4 or losers bracket winner.
         1.  If a rule isn't defined here, we fall back on Yahoo rules.

--- a/rules.md
+++ b/rules.md
@@ -26,7 +26,8 @@
         1.  This section provides a brief summary for those who don't need all the details.
         1.  If a conflict exists between this section and another section below, this section will be invalid.
     1.  League Settings
-        1.  14 teams, no keepers.
+        1.  14 teams
+        1.  No keepers / fresh start every year
         1.  Live snake draft on Monday, September 1 at 8:45pm ET.
         1.  Roster: 1 QB, 2 WR, 2 RB, 1 TE, 1 FLEX, 1 K, 1 DST, 4 bench, 2 IR.
         1.  Regular season: 13 weeks, each team plays every other team once.

--- a/rules.md
+++ b/rules.md
@@ -211,7 +211,7 @@
         1.  An exception may be made if the league determines by a majority vote that the player was scrambling "last-minute" to assemble a viable scoring team with incomplete information.
         1. Dropping a player to waivers shall never be considered waiver abuse if the player has already started their game for the week or would have otherwise been placed on waivers automatically by Yahoo.
     1.  Initiating an objection
-        1.  A manager may declare their intention to object by posting a new thread in the league message board stating the intention to object.
+        1.  A manager may declare their intention to object by posting in the league chatroom stating the intention to object.
         1.  An objection is not considered initiated until another manager seconds the intention to object.
         1.  Both the original intention to object and the seconding of the intention to object shall count as vote in favor of the objection.
         1.  Whenever an objection is initiated, the commissioner will clearly explain the situation publically to the league and outline the procedure for resolving it.
@@ -223,11 +223,10 @@
         1.  The commissioner will do his best to act quickly to finish an objection vote, in an attempt to avoid suspending moves.
     1.  <a id="conditional-moves">Conditional Moves and Roster Modifictions</a>
         1.  In the event moves are suspended or a vote is in progress that will affect a managers ability or willingness to make a move, managers may request to conditionally, based on the outcome of the objection vote, make a move.
-        1.  Conditional moves or roster modifictaions can be made by clearly stating the intention in the league message board or by communicating it to the commissioner who will then publically add it to the league message board.
+        1.  Conditional moves or roster modifictaions can be made by clearly stating the intention in the league chatroom or by communicating it to the commissioner who will then publically add it to the league chatroom.
             1. Commissioner gives no guarentee that he will act quickly in this situation as his number 1 priority will be to lift the suspension and/or resolve the league vote.
-        1.  Conditional moves will be processed after the objection vote in the order which they were publicly communicated to the league message board. For this reason, managers are encouraged to post it themselves, rather than wait for the commissioner.
+        1.  Conditional moves will be processed after the objection vote in the order which they were publicly communicated to the league chatroom. For this reason, managers are encouraged to post it themselves, rather than wait for the commissioner.
         1.  Managers should not consider specific conditional moves or roster modifications made after an objected move when voting on such objection.
-    1.  Any use of the word "veto" or derivations thereof in this document or in the Yahoo interface including the message board shall be interpreted as having the same meaning as an objection unless otherwise stated.
 1.  <a id="voting">Voting</a>
     1.  The commissioner will be the sole interpreter of all rules.
     1.  For ambiguous situations not clearly covered by the rules, the commissioner will first check for precedent from past rulings or deleted rules that may still be part of common league understanding.
@@ -240,7 +239,7 @@
     1.  Majority votes shall pass if at least half of the teams who didn't abstain, vote yes.
         1. A majority vote shall pass immediately when this condition is met.
     1.  An objection shall constitute a yes vote to reverse the objected action.
-    1.  All votes must be cast publicly, in the message board, unconditionally, unambiguously, and by the manager who's opinion they represent.
+    1.  All votes must be cast publicly, in the league chatroom, unconditionally, unambiguously, and by the manager who's opinion they represent.
         1.  Managers may change their vote at any time by casting a new vote that fits this criteria. The new vote will replace the old vote.
     1.  A majority vote will be required for:
         1.  Objections to trades, undoubtedly bad moves or roster decisions, waiver abuse, and any other moves that may be appropriately objected.

--- a/rules.md
+++ b/rules.md
@@ -11,7 +11,7 @@
     1.  [Moves](#moves)
         1.  [Trades](#trades)
     1.  [Objections](#objections)
-        1.  [Undoubtably bad moves](#undoubtably) (the most controversial rule we have, but it's important)
+        1.  [Undoubtedly bad moves](#undoubtedly) (the most controversial rule we have, but it's important)
         1.  [Suspending Moves](#suspending-moves)
     1.  [Voting and Objections](#voting)
     1.  [Seeding](#seeding)
@@ -20,9 +20,6 @@
     1.  [Abandoned Teams](#abandoned-teams)
     1.  [Outside Influence](#outside-influence)
     1.  [Rules Not Stated](#rules-not-stated)
-    1.  [Manager Responsibilities](#responsibilities)
-    1.  [Commissioner Responsibilities](#commissioner)
-    1.  [Incomplete NFL Season](#incomplete)
     1.  [Timezones](#timezones)
 1.  <a id="tldr">Summary</a>
     1.  Disclaimer
@@ -47,7 +44,7 @@
         1.  The winner of the losers bracket wins $100.
         1.  Teams should not create conflicts of interest with the league (e.g., betting that your team will lose or your players will do poorly).
     1.  Additional Rules
-        1.  It's against the rules to stop trying. If you make one or more "[undoubtably bad moves](#undoubtably)", the moves may be reversed, your lineup may be set for you, and your team may be put on autopilot.
+        1.  It's against the rules to stop trying. If you make one or more "[undoubtedly bad moves](#undoubtedly)," the moves may be reversed, your lineup may be set for you, and your team may be put on autopilot.
             1.  Do not stop trying! The weekly prizes, regular season prizes, and $100 for losers bracket mean you can still win your money back.
         1.  Trades are allowed and the trade deadline is week 10.
         1.  Trades will process immediately by Yahoo, but any manager may object within 24 hours and the trade will be reversed if a majority votes against it.
@@ -75,34 +72,34 @@
         1.  <a id="choosing-opponents">Playoffs will take place during weeks 14 through 16.</a>
             1.  Week 14 matchups
                 1.  Seed 2 chooses a team among seeds 3 through 7, that they will play against.
-                    1. This choice must be made on or before 1pm (ET) the Tuesday before the games or the choice will default to the bottom seed.
+                    1. This choice must be made on or before 1:00 PM (ET) on the Tuesday before the games, or the choice will default to the bottom seed.
                 1.  The top remaining seed (seed 3 or 4, whichever was not chosen by seed 2) chooses their opponent from the remaining teams.
-                    1. This choice must be made on or before 4pm (ET) the Tuesday before the games or the choice will default to the bottom seed.
+                    1. This choice must be made on or before 4:00 PM (ET) on the Tuesday before the games, or the choice will default to the bottom seed.
                 1.  The final two remaining teams play each other.
             1.  Week 15 matchups
                 1.  Seed 1 chooses a team among the three winners of week 14 to play against.
-                    1. This choice must be made on or before 1pm (ET) the Tuesday before the games or the choice will default to the bottom seed.
+                    1. This choice must be made on or before 1:00 PM (ET) on the Tuesday before the games, or the choice will default to the bottom seed.
                 1.  The remaining two winners of week 14 play against each other.
             1.  Week 16 matchups
-                1.  Superbowl
-                    1.  Two teams that won week 15 faceoff.
+                1.  Super Bowl
+                    1.  Two teams that won week 15 face off.
                     1.  Winner is 1st place
                     1.  Loser is 2nd place
                 1.  3rd place game
-                    1.  Two teams that lost week 15 faceoff.
+                    1.  Two teams that lost week 15 face off.
                     1.  Winner is 3rd place
                     1.  Loser is 4th place
         1.  Losers Bracket
             1.  A 7 team losers bracket will be set up for teams that do not make the playoffs (seeds 8-14).
             1.  Losers bracket seeding will use the same tie-breaking method as regular season seeding, except total wins and ties will be ignored and the primary seeding method will be [winning/losing streaks](#winning-streaks).
             1.  Losers bracket opponent selection follows the same rules as the main playoffs:
-                1.  Week 14: Seed 9 chooses first (by 1pm ET Tuesday), then the top remaining seed among 10-14 chooses (by 4pm ET Tuesday).
-                1.  Week 15: Seed 8 chooses among the winners (by 1pm ET Tuesday).
+                1.  Week 14: Seed 9 chooses first (by 1:00 PM ET Tuesday), then the top remaining seed among 10-14 chooses (by 4:00 PM ET Tuesday).
+                1.  Week 15: Seed 8 chooses among the winners (by 1:00 PM ET Tuesday).
         1.  Playoff choice delays
             1.  If the NFL or Yahoo causes a matchup to be incomplete by the time playoff opponent choices are due, or Yahoo delays waivers, then the choice deadline will be delayed until the first day after the matchups are complete or until the last day before the new waiver date.
         1.  FAB bonuses
             1.  Each team that makes the playoffs will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 14.
-            1.  Teams in the Superbowl will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 16.
+            1.  Teams in the Super Bowl will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 16.
             1.  Teams in the 3rd place game will receive half the amount of FAB they started the season with credited on top of their existing balance at the start of week 16.
         1.  Team locking
             1.  Teams will be locked once they are no longer in contention for 1st place, 3rd place, or winner of the losers bracket.
@@ -139,36 +136,36 @@
             1.  Ties will go to the team who scored the most points in the weeks that their earned their point for this prize, or a coin flip if still tied.
         1.  Weekly prizes ($400)
             1.  During weeks 10-13, each team in the top scoring matchup will win $50 each week.
-            1.  If there is a tie for highest scoring matchup, the tie goes to the pair of teams in the same matchup with the most total points on season so far, then coin flip.
+            1.  If there is a tie for highest scoring matchup, the tie goes to the pair of teams in the same matchup with the most total points in the season so far, then coin flip.
 1.  <a id="moves">Moves</a>
     1.  Moves are defined as player adds, trades, and drops.
-    1.  Players may only be dropped by a manager if the manager intends to immediately replace the slot on his or her roster.
+    1.  Players may only be dropped by a manager if the manager intends to immediately fill the slot on his or her roster.
     1.  <a id="trades">Trades</a>
         1.  Trades may only involve two teams.
-            1.  Threeway trades may be proposed or discussed, but the managers must work out a way to execute the trade in multiple steps using only two managers at a time.
-            1.  During the multipart execution of a threeway trade, managers may object to any component trade, independant of the other trades. Furthermore, managers are not beholden to any agreement to make a trade in the future based on the conditions of any previous trade. For these reasons, threeway trades can never be guarenteed.
+            1.  Three-way trades may be proposed or discussed, but the managers must work out a way to execute the trade in multiple steps using only two managers at a time.
+            1.  During the multipart execution of a three-way trade, managers may object to any component trade, independent of the other trades. Furthermore, managers are not beholden to any agreement to make a trade in the future based on the conditions of any previous trade. For these reasons, three-way trades can never be guaranteed.
         1.  Tradebacks and double trades are disallowed
             1.  Tradebacks are when a manager makes a trade to gain a player that he or she once traded away without the player falling to Waivers or Free Agency between trades.
             1.  Double trades are when a manager trades a player that was acquired in a different trade less than 36 hours prior.
-            1.  Tradebacks and double trades will be reversed immediately without a vote provided that a single manager points out that a tradeback or double trade occured within 24 hours of such trade.
+            1.  Tradebacks and double trades will be reversed immediately without a vote provided that a single manager points out that a tradeback or double trade occurred within 24 hours of such trade.
         1.  Expedited Trades
-            1.  Trades are processed immediately by Yahoo, but our rules states that trades may be objected within 24 hours after the trade is made and a vote to overturn a trade may take up to 36 hours after the trades is made.
+            1.  Trades are processed immediately by Yahoo, but our rules state that trades may be objected to within 24 hours after the trade is made and a vote to overturn a trade may take up to 36 hours after the trade is made.
             1.  Managers who make a trade to acquire a player less than 36 hours before they are expected to play may make [conditional moves or roster modifications](#conditional-moves) to be prepared for the case that their trade is objected and overturned.
 1.  <a id="objections">Objections</a>
-    1.  Any move may be objected by any manager within 24 hours after the move is made.
+    1.  Any move may be objected to by any manager within 24 hours after the move is made.
         1.  For trades this period starts when the trade is processed by Yahoo.
-    1.  <a id="undoubtably">Undoubtably bad moves</a>
-        1.  A manager must not take any actions, including making [moves](#moves) and setting active players, such that at the time the action is initiated it undoubtably diminishes the value of his or her team by reducing such team's chances of making the playoffs, finishing the regular season with the best possible seed, or winning the current matchup.
+    1.  <a id="undoubtedly">Undoubtedly bad moves</a>
+        1.  A manager must not take any actions, including making [moves](#moves) and setting active players, such that at the time the action is initiated it undoubtedly diminishes the value of his or her team by reducing such team's chances of making the playoffs, finishing the regular season with the best possible seed, or winning the current matchup.
             1.  Such actions may include, but are not limited to:
                 1.  Leaving roster positions empty when a healthy alternative was available on the bench or free agency (FA).
                 1.  Putting a player on active roster that has been long known to be not participating in the given week.
                 1.  Dropping an exceptionally valuable player when a significantly lesser valued alternative player was available to be dropped.
             1.  Exceptions may include:
-                1.  Pulling (or not pulling) a player from active roster after the manager's team has gained a lead that would be at risk if the player scored negative points.
+                1.  Pulling (or not pulling) a player from the active roster after the manager's team has gained a lead that would be at risk if the player scored negative points.
                 1.  In rare cases, leaving a roster position empty because no alternative exists on the bench and no benched player is worth dropping.
             1.  A successful objection regarding a roster decision to activate a specific player shall result in that players position on the roster being filled using the [autopilot](#autopilot) protocol.
             1.  Commissioner may make executive decisions at gametime to put a team on autopilot in cases of extraordinary neglect to prevent a league vote from delaying the correction.
-                1.  Comissioner will do his best to notify and get approval from as much of the league as possible before such decisions.
+                1.  Commissioner will do his best to notify and get approval from as much of the league as possible before such decisions.
                 1.  A league vote may reverse these executive decisions.
     1.  Waiver abuse
         1.  If a player is suspected of dropping and picking up players from free agency for the sole significant purpose of moving players to waivers, any moves made to accomplish this may be objected.
@@ -178,7 +175,7 @@
         1.  A manager may declare their intention to object by posting in the league chatroom stating the intention to object.
         1.  An objection is not considered initiated until another manager seconds the intention to object.
         1.  Both the original intention to object and the seconding of the intention to object shall count as vote in favor of the objection.
-        1.  Whenever an objection is initiated, the commissioner will clearly explain the situation publically to the league and outline the procedure for resolving it.
+        1.  Whenever an objection is initiated, the commissioner will clearly explain the situation publicly to the league and outline the procedure for resolving it.
         1.  When an objection is initiated, each manager in the league will have until 24 hours after the time the objection is initiated to perform a majority league vote to determine the outcome of the objection, but the entire process must complete within 36 hours of the original trade.
     1.  If an objection vote passes, the commissioner will do his best to reverse the actions that have been done as a result of the objection.
         1.  In some cases, this may include reversing other actions by other teams, if they are determined by a majority league vote to have been responses to the original objected action.
@@ -186,9 +183,9 @@
     1.  <a id="suspending-moves">In order to prevent multiple objections, the commissioner may suspend certain actions, including but not limited to moves, during a league vote until the vote is complete.</a>
         1.  The commissioner will do his best to act quickly to finish an objection vote, in an attempt to avoid suspending moves.
     1.  <a id="conditional-moves">Conditional Moves and Roster Modifictions</a>
-        1.  In the event moves are suspended or a vote is in progress that will affect a managers ability or willingness to make a move, managers may request to conditionally, based on the outcome of the objection vote, make a move.
-        1.  Conditional moves or roster modifictaions can be made by clearly stating the intention in the league chatroom or by communicating it to the commissioner who will then publically add it to the league chatroom.
-            1. Commissioner gives no guarentee that he will act quickly in this situation as his number 1 priority will be to lift the suspension and/or resolve the league vote.
+        1.  In the event moves are suspended or a vote is in progress that will affect a manager's ability or willingness to make a move, managers may request to conditionally, based on the outcome of the objection vote, make a move.
+        1.  Conditional moves or roster modifications can be made by clearly stating the intention in the league chatroom or by communicating it to the commissioner who will then publicly add it to the league chatroom.
+            1. The commissioner gives no guarantee that he will act quickly in this situation, as his number one priority will be to lift the suspension and/or resolve the league vote.
         1.  Conditional moves will be processed after the objection vote in the order which they were publicly communicated to the league chatroom. For this reason, managers are encouraged to post it themselves, rather than wait for the commissioner.
         1.  Managers should not consider specific conditional moves or roster modifications made after an objected move when voting on such objection.
 1.  <a id="voting">Voting and Objections</a>
@@ -203,13 +200,13 @@
     1.  Majority votes shall pass if at least half of the teams who didn't abstain, vote yes.
         1. A majority vote shall pass immediately when this condition is met.
     1.  An objection shall constitute a yes vote to reverse the objected action.
-    1.  All votes must be cast publicly, in the league chatroom, unconditionally, unambiguously, and by the manager who's opinion they represent.
+    1.  All votes must be cast publicly, in the league chatroom, unconditionally, unambiguously, and by the manager whose opinion they represent.
         1.  Managers may change their vote at any time by casting a new vote that fits this criteria. The new vote will replace the old vote.
     1.  A majority vote will be required for:
         1.  Objections to trades, undoubtedly bad moves or roster decisions, waiver abuse, and any other moves that may be appropriately objected.
         1.  Disambiguating any rules.
     1.  Managers are disqualified from voting on a particular issue if they are directly involved with what is being voted upon.
-        1.  Commissioner may make initial ruling, but will not participate in the league vote if he is directly involved.
+        1.  The commissioner may make an initial ruling, but will not participate in the league vote if he is directly involved.
         1.  Managers directly involved include but are not limited to
             1.  Managers gaining or losing players in a trade.
             1.  Managers matched up against a team that's being accused of making poor roster decisions.
@@ -225,12 +222,12 @@
             1.  The previous two conditions will be applied iteratively backwards through the season until the tie is broken.
                 1.  For example: if two teams both end with 3-game win streaks, we compare their losing streaks before those wins, then their win streaks before those losses, and so on.
         1.  Most points in regular season
-        1.  Coin flip 
+        1.  Coin flip.
     1.  <a id="ties">Ties in playoffs</a>
         1.  In the event of a tied game during the postseason, the win will be awarded to the team with the bottom seed.
-1.  <a id="abandoned-teams">Amandoned Teams</a>
+1.  <a id="abandoned-teams">Abandoned Teams</a>
     1.  Managers should keep an eye on their teams at least once a week, set their lineups in a way that they expect to win their games, and add and drop players to prepare to win more games.
-        1.  Managers should stay competitive even if they don't think they can improve their chances of making the playoffs or win prizes.
+        1.  Managers should stay competitive even if they don't think they can improve their chances of making the playoffs or winning prizes.
     1.  Teams who fail to stay competitive may be declared abandoned and put through the abandoned team protocol if the following conditions are met.
         1.  A manager in the league accuses a manager of neglecting their team.
             1.  The accusing manager should describe the nature of the neglect.
@@ -241,7 +238,7 @@
     1.  <a id="autopilot">Autopilot</a>
         1.  When a team is placed on autopilot, the commissioner will set their line up each week in a predetermined fashion.
         1.  Any conditional moves or conditional roster modifications made by the manager will supersede the following rules provided that they are not successfully objected to.
-        1.  At time of the start of each game, the starting roster will be set to the players on the team or available on FA that have the greatest Yahoo projection. Ties in projections will be broken by coin flip.
+        1.  At the time of the start of each game, the starting roster will be set to the players on the team or available on FA that have the greatest Yahoo projection. Ties in projections will be broken by coin flip.
         1.  Setting the roster may be done slightly after the game starts so that the projections lock in to their final value before the decision is made and so that any other team not on autopilot may have first dibs on any player.
         1.  If a player must be dropped to accommodate a FA add, the dropped player will be chosen using the following method:
             1.  If at any point, only one player is left, drop him.
@@ -251,7 +248,7 @@
             1.  Drop the remaining player with the smallest maximum projected weekly score left of the weeks leading to week 14 in the regular season and 17 in the playoffs.
     1.  The commissioner may at any time call a majority league vote to take a team off autopilot.
     1.  Elective autopilot
-        1.  Subject to commissioner approval, any manager may have their team temporarily put on autopilot if they are preoccupied with a life emergency by letting the comissioner know of their preoccupation.
+        1.  Subject to commissioner approval, any manager may have their team temporarily put on autopilot if they are preoccupied with a life emergency by letting the commissioner know of their preoccupation.
 1.  <a id="outside-influence">Outside influence</a>
     1.  No external value to the league, including monetary value or a "gentleman's agreement," may be exchanged between managers for moves or any other manager decision.
         1.  For example, managers may not agree to make a trade today in exchange for an obligation to make some other trade at another time.
@@ -260,77 +257,5 @@
 1.  <a id="rules-not-stated">Rules Not Stated</a>
     1.  All rules not stated in this document will be settled by our league configuration on Yahoo! Sports.
     1.  Anything still left ambiguous may be determined by a majority league vote.
-1.  <a id="responsibilities">Manager responsibilities</a>
-    1.  Managers should do their best to win each and every matchup.
-    1.  Managers should look out for actions which seem to break the rules and call them out to the commissioner or publicly object.
-    1.  Managers should be respectful of all other managers in the league and the rules of the league.
-    1.  Managers should use common sense and ethics when presented with a questionably legal or moral decision.
-    1.  Managers should not celebrate the injury of a real life player.
-1.  <a id="commissioner">Commissioner responsibilities</a>
-    1.  Commissioner will do his best to explain the rules and consequences of any event or action.
-    1.  Commissioner will be the sole interpreter of all rules.
-    1.  Commissioner will make himself available to answer all reasonable questions in a reasonable time frame.
-    1.  Commissioner will hold all prize money in a safe place, unassociated with personal funds.
-    1.  Commissioner will always be a skeptic and play "devil's advocate" in decisions, even if he already has a strong opinion.
-1. <a id="incomplete">Incomplete NFL Season</a>
-    1. Completed weeks
-        1.  A week in the NFL will be considered completed if at least 8 games are played and scored.
-        1.  Any week that is not completed will be voided from this league and no wins, losses, ties, or points will be counted toward any totals for prize payout or seeding purposes.
-        1.  The regular season will be considered to be completed if at least 8 regular season weeks are completed.
-    1.  If the NFL does not play a full season, the league fees and prizes may be modified as described in this section.
-        1. League Fees
-            1.  If no regular season weeks are completed, all league fees will be returned.
-            1.  If 1 to 3 regular season weeks are completed, league fees will be adjusted to $50.
-            1.  If 4 to 7 regular season weeks are completed, league fees will be adjusted to $100.
-            1.  If at least 8 regular season weeks are completed and no playoff weeks are completed, league fees will be adjusted to $150.
-            1.  If 8 to 14 regular season weeks are completed and at least one playoff week is completed, league fees will remain $200.
-        1. Prizes
-            1.  Any split prizes will be rounded down to the nearest $1 and the remaining change will be given to the tied team with the highest points or to a randomly chosen team if still tied.
-            1.  If no regular season weeks are completed, no prizes will be paid.
-            1.  If at least 1 regular season week is completed, Best Worst Player ($50) and Points ($150) will be paid as usual.
-            1.  If at least 2 regular season weeks are completed, Best Worst Week ($50) and Best Week ($50) will be paid as usual.
-            1.  If at least 3 regular season weeks are completed, Most Best Weeks ($50) will be paid as usual.
-            1.  If at least 4 regular season weeks are completed, Weekly Prizes ($400 total) will be applied to the final 4 weeks of the regular season games that are completed.
-            1.  If the regular season is not completed, each of the following rules will supersede:
-                1.  The playoffs will be canceled and considered not completed
-                1.  No playoff prizes will be paid
-                1.  All remaining prize funds will be distributed as:
-                    1.  40% to the 1st in standings
-                    1.  30% to the 2nd in standings
-                    1.  20% to the 3rd in standings
-                    1.  10% to the 4th in standings
-            1.  If the regular season is completed, but some playoff weeks are not completed, the following rules will supersede:
-                1.  If week 15 is completed:
-                    1.  Week 15 rules act as usual
-                    1.  The 2 losing teams win the 5th and 6th place prizes.
-                    1.  If week 16 is completed:
-                        1.  The two winners of week 16 split the 1st and 2nd place prizes.
-                        1.  The two losers of week 16 split the 3rd and 4th place prizes.
-                    1.  If week 16 is not completed:
-                        1.  Week 17 is prepared to be played as both weeks 16 and 17 under the usual set of rules.
-                        1.  The 1 seed chooses who they would like to play against as the week 16 game during week 17 while the other two teams play against each other.
-                        1.  The two winners of the fake week 16 game are simulated to play each other in the superbowl using the same scores to determine 1st and 2nd place.
-                        1.  The two losers of the fake week 16 game are simulated to play each other in the 3rd place game using the same scores to determine 3rd and 4th place.
-                        1.  If week 17 is not played, the final 4 teams split 1st, 2nd, 3rd, and 4th.
-                1.  If week 15 is not completed:
-                    1.  Week 16 is prepared to be played as both weeks 15 and 16 under the usual set of rules.
-                    1.  The 2 seed choose their matchup for the fake week 15 game as usual.
-                    1.  The 1 seed chooses rank order who they'd like to play against in the week 16 game depending on the results of the fake week 15 game before it's played.
-                    1.  If week 16 is completed:
-                        1.  The two winning teams move on to the Superbowl while the two losing teams move on the the 3rd place game.
-                        1.  If week 17 is not completed, the top two teams split 1st and 2nd while the bottom two teams split 3rd and 4th.
-                    1.  If week 16 is not completed:
-                        1.  Week 17 is prepared to be a combination of weeks 15, 16, and 17 using the same methods as described above for combining weeks 15 and 16 and combining weeks 16 and 17.
-                        1.  If week 17 is not completed:
-                            1. The 1st ($100) and 2nd ($50) place in regular season prizes are replaced with the following prizes for standings in the regular season:
-                                1. 1st - $500
-                                2. 2nd - $250
-                                3. 3rd - $200
-                                4. 4th - $150
-                                5. 5th through 7th - $100 each
-    1.  Regular Season Standings
-        1.  If less than 4 weeks are completed, regular season standings will be based solely on total points.
-        1.  If less than 8 weeks are completed, there will be no tie breakers for regular season standings. Instead any prize paid to a specific standing will be split by all teams who tied for that position.
-        1.  If less than 14 weeks are completed, head to head tie breakers will only be used if all teams being compared played the same number of head to head games.
 1. <a id="time">Timezones</a>
-    1. All times in these rules are Easter Standard Time unless otherwise stated.
+    1. All times in these rules are Eastern Time unless otherwise stated.

--- a/rules.md
+++ b/rules.md
@@ -154,7 +154,7 @@
             1.  Managers will have a chance to review the rules before committing to the league.
                 1.  If 12 managers do not commit, the initial payment will be refunded.
     1.  <a id="payouts">Payouts</a>
-        1.  Playoffs ($1,900 total)
+        1.  Playoffs ($2,000 total)
             1.  1st place - $1,100
             1.  2nd place - $450
             1.  3rd place - $350
@@ -183,8 +183,6 @@
         1.  Weekly prizes ($400)
             1.  During weeks 10-13, each team in the top scoring matchup will win $50 each week.
             1.  If there is a tie for highest scoring matchup, the prize will be split among all tied teams.
-        1.  All prizes will be paid out no later than the real NFL Super Bowl.
-        1.  After week 15, any players remaining in the playoffs may renegotiate the prizes for 1st through 4th place provided that the new prize distribution is proposed to the commissioner by the highest seeded remaining manager and all other remaining managers accept.
 1.  <a id="moves">Moves</a>
     1.  Moves are defined as player adds, trades, and drops.
     1.  Players may only be dropped by a manager if the manager intends to immediately replace the slot on his or her roster.

--- a/rules.md
+++ b/rules.md
@@ -36,14 +36,14 @@
         1.  The regular season is 13 weeks, with each team playing every other team exactly once.
         1.  The playoffs will have 8 teams, four will get a bye, and take place on weeks 14 through 17.
         1.  The draft time is on the Sunday before the first game each season at 8pm.
-        1.  We'll use FAAB to determine waiver claims and break ties with least recently used.
+        1.  We'll use FAB to determine waiver claims and break ties with least recently used.
         1.  League fee is $200.
         1.  Trades are allowed and the trade deadline will be the Saturday of week 12.
         1.  Trades will process immediately by Yahoo, but any manager may object and a majority vote will determine whether the trade is overturned.
         1.  In this league, it is against the rules to stop trying. If you make an "[undoubtably bad move](#undoubtably)", your line up will be set for you and your team may be put on autopilot.
         1.  Only the top 4 playoff finishers win money: 1st ($1,000), 2nd ($400), 3rd ($350), and 4th ($100).
         1.  The team who scores the most points wins $200.
-        1.  There are 4 other prizes of $50 each, plus $50 for most FAAB remaining among playoff teams.
+        1.  There are 4 other prizes of $50 each, plus $50 for most FAB remaining among playoff teams.
         1.  Weekly prizes: $50 for each team in the top scoring matchup during weeks 10, 11, 12, and 13.
         1.  The winner of the losers bracket wins $100.
         1.  People shouldn't create conflicts of interest with the league.
@@ -131,6 +131,12 @@
         1.  Losers Bracket
             1.  A 7 team losers bracket will be set up for teams that do not make the playoffs (seeds 8-14).
             1.  Losers bracket seeding will use the same tie-breaking method as regular season seeding, except total wins and ties will be ignored and the primary seeding method will be winning/losing streaks.
+        1.  FAB bonuses
+            1.  Each team that makes the playoffs will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 14.
+            1.  Teams in the Superbowl will receive the same amount of FAB they started the season with credited on top of their existing balance at the start of week 16.
+            1.  Teams in the 3rd place game will receive half the amount of FAB they started the season with credited on top of their existing balance at the start of week 16.
+        1.  Team locking
+            1.  Teams will be locked once they are no longer in contention for 1st place, 3rd place, or winner of the losers bracket.
 1.  <a id="money">Money</a>
     1.  <a id="fees">League Fees</a>
         1.  Payment
@@ -169,9 +175,9 @@
         1.  Weekly prizes ($400)
             1.  Each team in the top scoring matchup during weeks 10, 11, 12, and 13 will win $50 each.
             1.  If there is a tie for highest scoring matchup, the prize will be split among all tied teams.
-        1.  Most FAAB ($50)
-            1.  The team that makes the playoffs with the most FAAB remaining will win $50.
-            1.  Ties will be broken by highest waiver priority (same as FAAB tie-breaking for player pickups).
+        1.  Most FAB ($50)
+            1.  The team that makes the playoffs with the most FAB remaining will win $50.
+            1.  Ties will be broken by highest waiver priority (same as FAB tie-breaking for player pickups).
         1.  Losers bracket ($100)
             1.  Winner of the losers bracket will win $100.
         1.  All prizes will be paid out no later than the real NFL Super Bowl.


### PR DESCRIPTION
# Rule Changes This Season

- **League size & structure**: Expanded from 12 to 14 teams. Divisions removed. Each team plays every other team once (13-week regular season).

- **Roster & settings**: Bench reduced to 4 spots, IR expanded to 2.

- **Draft**: Live snake draft on Monday, September 1 at 8:45 PM ET. Draft order finalized after dues are paid, at least 1 hour before the draft.

- **Keepers**: No more keepers.

- **Playoffs**: Expanded from 6 teams to 7, running Weeks 14–16 (instead of 15–17). Only the 1 seed gets a bye (previously top 2). The losers bracket also has 7 teams, seeded by end-of-season win/loss streaks instead of overall record.

- **Playoff mechanics**: New FAB bonuses awarded at the start of playoffs and again before the Super Bowl, ensuring winners bracket teams have priority over losers bracket teams. Teams eliminated from contention for top 4 or the losers bracket championship are locked from making moves.

- **Trade rules**: Trade deadline moved up to Week 10 (previously Week 12). Objection window clarified to start when Yahoo processes the trade.

- **Prizes**:
  - Playoff payouts updated: 1st place $1,100; 2nd $450; 3rd $350; 4th $100.  
  - Most points prize reduced from $150 → $100.  
  - Added weekly prizes: $50 to each team in the top-scoring matchup during Weeks 10–13.  
  - New $100 prize for the losers bracket champion.  
  - Still includes $50 side awards: Best Worst Player, Best Worst Week, Best Week, and Most Best Weeks.

- **Voting & commissioner powers**: Rules about proposing/amending rules have been removed. The commissioner is now the sole interpreter of rules, with league votes used only for ambiguities or objections.

- **Spelling, grammar, and consistency**: Cleaned up capitalization, date/time formatting, and list structure for clarity. Removed duplicative and outdated rules.
